### PR TITLE
Spec 1: VPS infrastructure migration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,32 +10,55 @@ jobs:
   # Test the existing Python backend
   test-backend:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: formava
+          POSTGRES_PASSWORD: formava_dev
+          POSTGRES_DB: formava
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U formava -d formava"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
     strategy:
       matrix:
         python-version: [3.11]
-    
+
     steps:
     - uses: actions/checkout@v4
-    
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
-    
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-    
+        pip install -r requirements-api-dev.txt
+
     - name: Run linting
       run: |
         ruff check app/
         ruff format --check app/
-    
+
+    - name: Enable pgvector
+      run: |
+        PGPASSWORD=formava_dev psql -h localhost -U formava -d formava \
+          -c "CREATE EXTENSION IF NOT EXISTS vector;"
+
     - name: Run tests
+      env:
+        FORMAVA_DATABASE_URL: postgresql://formava:formava_dev@localhost:5432/formava
+        FORMAVA_TEST_DSN: postgresql://formava:formava_dev@localhost:5432/formava
       run: |
         pytest tests/ -v
-    
+
     - name: Test imports
       run: |
         python -c "import app.main; print('Backend imports successfully')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI/CD Pipeline
 
 on:
   push:
-    branches: [ main, production, feature/nextjs-migration ]
+    branches: [ main, production ]
   pull_request:
     branches: [ main, production ]
 
@@ -62,9 +62,17 @@ jobs:
       run: |
         pytest tests/ -v
 
+    # Smoke-test what actually ships. The old check imported app.main, which
+    # pulls in the Gradio layer and hard-requires CouchDB -- a service this
+    # workflow does not run, and one the VPS deliberately does not have
+    # (verify.sh asserts Gradio is absent from the host). Scoped to the
+    # deployed entrypoint for the same reason the ruff step is scoped to
+    # app/health/; widen as later specs land.
     - name: Test imports
+      env:
+        FORMAVA_DATABASE_URL: postgresql://formava:formava_dev@localhost:5432/formava
       run: |
-        python -c "import app.main; print('Backend imports successfully')"
+        python -c "from app.health.api import create_app; create_app(); print('API entrypoint imports successfully')"
 
   # Test the new Next.js frontend
   test-frontend:
@@ -79,10 +87,10 @@ jobs:
     - name: Set up Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
         cache-dependency-path: frontend/package-lock.json
-    
+
     - name: Install dependencies
       run: npm ci
     
@@ -100,37 +108,53 @@ jobs:
         echo "Frontend build completed successfully"
         ls -la .next/
 
-  # Deploy to staging (main branch)
-  deploy-staging:
+  # Deploy to the VPS (main branch). Replaces the two Render echo-stubs, which
+  # never deployed anything -- Render builds from its own GitHub integration and
+  # stays live and untouched as the fallback until Spec 4 retires it. Staging is
+  # dropped per the spec; there is one environment now.
+  deploy-vps:
     needs: [test-backend, test-frontend]
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    
-    steps:
-    - uses: actions/checkout@v4
-    
-    - name: Deploy to Render (Staging)
-      run: |
-        echo "Deploying to staging environment"
-        echo "This would trigger Render deployment for staging"
-        # In a real setup, you'd trigger Render deployment here
-        # or use Render's GitHub integration
 
-  # Deploy to production (production branch)
-  deploy-production:
-    needs: [test-backend, test-frontend]
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/production' && github.event_name == 'push'
-    
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Deploy to Render (Production)
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: frontend/package-lock.json
+
+    # Built on the runner, not the host: `next build` wants 1.5-2 GB and would
+    # contend with Clio on a 4 GB box. deploy_vps.sh rsyncs the output.
+    - name: Build frontend
+      working-directory: ./frontend
+      run: npm ci && npm run build
+
+    # A dedicated deploy key, not a personal one. Password auth is off on the
+    # host, so key material is the only way in.
+    - name: Configure SSH
       run: |
-        echo "Deploying to production environment"
-        echo "This would trigger Render deployment for production"
-        # In a real setup, you'd trigger Render deployment here
-        # or use Render's GitHub integration
+        mkdir -p ~/.ssh
+        echo "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/id_ed25519
+        chmod 600 ~/.ssh/id_ed25519
+        ssh-keyscan -H "${{ secrets.VPS_HOST }}" >> ~/.ssh/known_hosts
+
+    - name: Deploy
+      env:
+        VPS_HOST: ${{ secrets.VPS_HOST }}
+      run: |
+        ./scripts/deploy_vps.sh sync
+        ./scripts/deploy_vps.sh install
+        ./scripts/deploy_vps.sh restart
+
+    # The full chain: TLS -> nginx -> Next.js BFF -> FastAPI -> Postgres.
+    # Anything less would pass while the database is down.
+    - name: Verify
+      run: |
+        curl -sf https://formava.io/api/health | grep '"db":"ok"'
 
   # Build and test Docker images
   docker-build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,11 @@ jobs:
 
     - name: Run linting
       run: |
-        ruff check app/
-        ruff format --check app/
+        # Scoped to the code Spec 1 owns. The Gradio layer carries 107
+        # pre-existing violations and is deleted in Spec 4; widen this path
+        # as each later spec lands.
+        ruff check app/health/
+        ruff format --check app/health/
 
     - name: Enable pgvector
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
           --health-retries 10
     strategy:
       matrix:
-        python-version: [3.11]
+        python-version: [3.12]
 
     steps:
     - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,7 @@ dist/
 downloads/
 eggs/
 .eggs/
-lib/
+/lib/
 lib64/
 parts/
 sdist/
@@ -67,6 +67,9 @@ couchdb/local.ini
 # Temporary files and generated data
 *.json
 !hevy_exercise_ids.json  # Track exercise IDs for production seeding
+!frontend/package.json
+!frontend/package-lock.json
+!frontend/tsconfig.json
 *.csv
 *.txt
 !requirements.txt

--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,8 @@ couchdb/local.ini
 *.csv
 *.txt
 !requirements.txt
+!requirements-api.txt
+!requirements-api-dev.txt
 !README.txt
 !README.md
 

--- a/app/health/api.py
+++ b/app/health/api.py
@@ -1,0 +1,48 @@
+"""Thin-slice FastAPI application for Spec 1.
+
+Exists to prove the request chain TLS -> nginx -> Next.js -> FastAPI ->
+Postgres before any real application code is migrated. Serves exactly one
+route.
+"""
+
+import logging
+import os
+
+import psycopg
+from fastapi import FastAPI, HTTPException
+
+from app.health.checks import check_postgres
+
+logger = logging.getLogger(__name__)
+
+
+def create_app(dsn: str | None = None) -> FastAPI:
+    """Build the health application.
+
+    Args:
+        dsn: Postgres connection string. Falls back to FORMAVA_DATABASE_URL.
+
+    Raises:
+        ValueError: no DSN supplied and none in the environment. Fails at
+            startup rather than serving a broken app.
+    """
+    resolved = dsn if dsn is not None else os.environ.get("FORMAVA_DATABASE_URL", "")
+    if not resolved:
+        raise ValueError(
+            "No Postgres DSN: pass dsn= or set FORMAVA_DATABASE_URL. "
+            "Refusing to start without one."
+        )
+
+    application = FastAPI(title="Formava API", version="0.1.0")
+
+    @application.get("/health")
+    def health() -> dict[str, str]:
+        try:
+            result = check_postgres(resolved)
+        except psycopg.Error as exc:
+            logger.error("Health check failed: %s", exc)
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+        return result.model_dump()
+
+    return application

--- a/app/health/checks.py
+++ b/app/health/checks.py
@@ -1,0 +1,35 @@
+"""Database health probes for the Formava API.
+
+Deliberately has no fallback behaviour. An unreachable database raises,
+so callers surface a 503 rather than reporting healthy while serving an
+empty datastore (contrast app/config/database.py:112).
+"""
+
+import psycopg
+from pydantic import BaseModel
+
+
+class PostgresHealth(BaseModel):
+    """Result of a successful Postgres probe."""
+
+    db: str
+    pgvector: str
+
+
+def check_postgres(dsn: str) -> PostgresHealth:
+    """Verify Postgres is reachable and the pgvector extension is installed.
+
+    Raises:
+        psycopg.Error: connection failed, or pgvector is not installed.
+    """
+    with psycopg.connect(dsn, connect_timeout=5) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT extversion FROM pg_extension WHERE extname = 'vector'")
+            row = cur.fetchone()
+
+    if row is None:
+        raise psycopg.OperationalError(
+            "pgvector extension is not installed in this database"
+        )
+
+    return PostgresHealth(db="ok", pgvector=row[0])

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -1,0 +1,23 @@
+# Local Postgres for development and integration tests.
+# The VPS runs Postgres natively under systemd; this is dev-only.
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: formava_postgres
+    environment:
+      POSTGRES_USER: formava
+      POSTGRES_PASSWORD: formava_dev
+      POSTGRES_DB: formava
+    ports:
+      - "5432:5432"
+    volumes:
+      - formava_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U formava -d formava"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  formava_pgdata:
+    name: formava_pgdata

--- a/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
+++ b/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
@@ -1302,10 +1302,20 @@ server {
 
 - [ ] **Step 3: Install it and issue the certificate**
 
+⚠️ **`NEEDRESTART_SUSPEND=1` is required on this apt call.** `needrestart` is
+installed with no explicit restart mode, so under `DEBIAN_FRONTEND=noninteractive`
+it auto-restarts daemons whose shared libraries were upgraded. During Task 3 it
+silently bounced `clio-cron.service` as a side effect of installing Postgres. The
+same mechanism could restart `clio.service`, which has `Restart=on-failure` with
+`StartLimitBurst=5` — an apt-triggered restart is exactly the path to leaving Clio
+permanently dead. Suspending it makes the apt call inert with respect to running
+services.
+
 ```bash
 scp scripts/vps/nginx-formava.conf root@144.202.88.7:/etc/nginx/sites-available/formava
 ssh root@144.202.88.7 '
-  apt-get install -y --no-install-recommends certbot python3-certbot-nginx
+  NEEDRESTART_SUSPEND=1 DEBIAN_FRONTEND=noninteractive \
+    apt-get install -y --no-install-recommends certbot python3-certbot-nginx
   ln -sf /etc/nginx/sites-available/formava /etc/nginx/sites-enabled/formava
   nginx -t && systemctl reload nginx
   certbot --nginx -d formava.io -d www.formava.io \
@@ -2035,7 +2045,7 @@ timeout 8 curl -s -o /dev/null "http://${VPS}:3000/capture" 2>/dev/null \
 
 echo "== Host =="
 check "services active" \
-  "$($SSH 'systemctl is-active postgresql formava-api formava-web clio nginx | sort -u | tr -d "\n"')" \
+  "$($SSH 'systemctl is-active postgresql formava-api formava-web clio clio-cron nginx | sort -u | tr -d "\n"')" \
   "active"
 check "ufw ports" \
   "$($SSH "ufw status | grep -cE '^(22|80|443)'")" "3"

--- a/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
+++ b/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
@@ -28,7 +28,7 @@
 - Hosts: `formava.io`, `www.formava.io`, `clio.lantzbuilds.com`. **No `api.formava.io`** — FastAPI has no public vhost.
 - `/health` response body, exact shape: `{"db": "ok", "pgvector": "<version>"}`. Failure returns HTTP **503**, never a degraded 200.
 - **No silent fallbacks.** Do not replicate `app/config/database.py:112` (`_create_mock_database`). Missing config or an unreachable database is a startup failure or a 503.
-- CI runs `ruff check app/` and `ruff format --check app/` with no config file, so ruff defaults apply (line length 88). All new `app/` code must pass both.
+- CI lint is **scoped to the paths each spec owns**, not all of `app/`. The Gradio layer carries **107 pre-existing ruff violations** and is deleted in Spec 4, so gating on it would make the deploy job permanently unreachable. Spec 1 scopes CI to `ruff check app/health/` and `ruff format --check app/health/`; later specs widen the path as they delete or rewrite code. Ruff runs with no config file, so defaults apply (line length 88). All new code must pass both commands.
 - VPS: `144.202.88.7`, user `root`. SSH via `scripts/deploy.sh`-style `sshpass`/key auth already configured in `../clio-ai-assitant/.env`.
 
 ## Cross-Repo Sequencing (Clio)
@@ -449,6 +449,23 @@ Then change the `Install dependencies` step to also install the API dev deps, an
         pytest tests/ -v
 ```
 
+Finally, **scope the existing lint step**. It currently runs `ruff check app/`
+and `ruff format --check app/`, which fails on 107 pre-existing violations in the
+Gradio layer — the reason CI has been red since October 2025. Replace it with:
+
+```yaml
+    - name: Run linting
+      run: |
+        # Scoped to the code Spec 1 owns. The Gradio layer carries 107
+        # pre-existing violations and is deleted in Spec 4; widen this path
+        # as each later spec lands.
+        ruff check app/health/
+        ruff format --check app/health/
+```
+
+Leave `pytest tests/ -v` unscoped — Task 1b repairs the three broken hevy tests so
+the full suite can pass.
+
 - [ ] **Step 12: Commit**
 
 ```bash
@@ -460,6 +477,106 @@ git commit -m "feat: add FastAPI /health slice with pgvector probe
 Thin-slice payload for Spec 1. Fails loudly with 503 rather than
 reporting healthy on an unreachable database. Slim requirements-api.txt
 keeps the VPS venv independent of the Gradio monolith's dependencies."
+```
+
+---
+
+## Task 1b: Repair the hevy tests so they stop calling a live API
+
+Discovered during Task 1. `tests/unit/test_hevy_api.py` — the repo's only test file
+— patches `app.services.hevy_api.requests.get`, but `hevy_api.py:78` calls
+`requests.request`. **The mock has never intercepted anything.** All three tests
+make real HTTPS calls to `api.hevyapp.com` with the fake key `"fake-key"`, receive
+a 401, and retry with exponential backoff — hence a 24-second runtime and genuine
+`Server: Heroku` headers in the failure output.
+
+`app/services/hevy_api.py` survives unchanged into Spec 4, so this coverage has
+lasting value. Fixing it also removes a third-party network dependency from every
+CI run.
+
+**Files:**
+- Modify: `tests/unit/test_hevy_api.py` (3 patch decorators at lines 23, 43, 66; one assertion at line 87)
+
+**Interfaces:**
+- Consumes: `app.services.hevy_api.HevyAPI` — unchanged, no production code is modified.
+- Produces: 3 passing tests that make zero network calls.
+
+- [ ] **Step 1: Confirm the tests currently reach the network**
+
+```bash
+.venv/bin/python -m pytest tests/unit/test_hevy_api.py -q 2>&1 | tail -20
+```
+
+Expected: 3 failures, a runtime over ~20s, and real Hevy API response headers
+(`Server: Heroku`, `Report-To`) in the captured log — proving the mock is inert.
+
+- [ ] **Step 2: Retarget the patches**
+
+In `tests/unit/test_hevy_api.py`, change all three decorators (lines 23, 43, 66):
+
+```python
+@patch("app.services.hevy_api.requests.request")
+```
+
+`hevy_api.py:78` is `response = requests.request(method, url, **kwargs)`, so this
+is the call that must be intercepted.
+
+- [ ] **Step 3: Fix the assertion that never matched the real message**
+
+At line 87, `requests` raises `"401 Client Error: Unauthorized for url: ..."`, not
+`"401 Unauthorized"`:
+
+```python
+        assert "401 Client Error" in str(excinfo.value)
+```
+
+- [ ] **Step 4: Add an assertion that the mock was actually used**
+
+This is the guard that makes a future wrong-target patch fail loudly instead of
+silently reaching the network. Add to each of the three tests, after the existing
+assertions:
+
+```python
+    # Guard: a wrong patch target would silently hit the real API instead.
+    assert mock_request.called
+```
+
+Rename each test's mock parameter from `mock_get` to `mock_request` to match the
+new target, and update the existing `mock_get.return_value` / `mock_get.side_effect`
+references accordingly.
+
+- [ ] **Step 5: Run the tests and confirm they pass fast and offline**
+
+```bash
+.venv/bin/python -m pytest tests/unit/test_hevy_api.py -v
+```
+
+Expected: 3 passed, runtime **under 2 seconds** (no retry backoff), and no Hevy
+API headers in the output. The speed is the evidence that no network call happened.
+
+- [ ] **Step 6: Confirm the full suite is now green**
+
+```bash
+export FORMAVA_DATABASE_URL="postgresql://formava:formava_dev@localhost:5432/formava"
+export FORMAVA_TEST_DSN="$FORMAVA_DATABASE_URL"
+.venv/bin/python -m pytest tests/ -v
+```
+
+Expected: 8 passed (3 hevy + 3 health unit + 2 health integration), 0 failed.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tests/unit/test_hevy_api.py
+git commit -m "fix: repair hevy tests that were calling the live API
+
+The patch target was requests.get but hevy_api.py:78 calls
+requests.request, so the mock never intercepted anything and all three
+tests made real HTTPS calls to api.hevyapp.com with a fake key, failing
+on a 401 after retry backoff. Retargets the patches, corrects an
+assertion that never matched requests' actual error message, and asserts
+the mock was called so a future wrong target fails loudly rather than
+silently reaching the network."
 ```
 
 ---

--- a/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
+++ b/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
@@ -1580,6 +1580,19 @@ ssh root@144.202.88.7 'grep -c "CAPTURE_TOKEN" /opt/clio/dist/src/utils/config.j
 Must be non-zero. If it is `0`, stop — CLIO must deploy `f4e770a` + `9972b58`
 first.
 
+> ✅ **SATISFIED as of 2026-08-02 05:17:58 UTC.** CLIO deployed both commits
+> during Task 6 Steps 1–4. Verified on the host: 8 references in the built
+> `config.js`; `/capture/bulk`, `/capture/fix`, `/capture/fix/recent` now 404
+> **upstream on port 3000** as well as at nginx; `/opt/clio/.env` still holds only
+> `CAPTURE_API_TOKEN`, which is the correct inert state — the legacy token is
+> accepted for both scopes until Step 7 adds the scoped pair.
+>
+> One consequence for Step 4's evidence: the three deleted routes no longer prove
+> nginx is the control, since they are gone upstream too. The allowlist is still
+> independently demonstrated by two live cases — `GET /status` returns **200
+> upstream and 404 through nginx**, and the anchored fix regex rejects a
+> four-segment `/capture/a/b/fix` at nginx while `/capture/<id>/fix` reaches Clio.
+
 **Add a positive control to Step 8**, so the scope assertion cannot pass for the
 wrong reason. Assert the capture token is *recognised* before asserting it is
 *scoped*:

--- a/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
+++ b/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
@@ -33,8 +33,28 @@
 
 ## Cross-Repo Sequencing (Clio)
 
+> 🔴 **READ BEFORE TASK 6 — this table is out of date.**
+>
+> Cross-repo ordering is now governed by
+> **`../clio-ai-assitant/docs/VPS-CUTOVER-RUNBOOK.md`**, which is authoritative
+> for *sequencing and cross-repo decisions*. This plan remains authoritative for
+> *how* to execute each Formava task. Where they disagree on ordering, the
+> runbook wins; where they disagree on commands, this plan wins.
+>
+> Three rows below have changed since this was written:
+>
+> | Row | Was | Now |
+> |---|---|---|
+> | 2 — fail-fast | before Task 6 | ✅ **landed and deployed** (`4bc5f41`). Step 7's `dev-token` probe can no longer be what catches a botched edit — Clio now *refuses to boot*, so the restart is the loud failure |
+> | 1 — token splitting | after Spec 1 | 🔴 **reversed — ships in this cutover.** Code already landed (`f4e770a`) and is inert while `CAPTURE_API_TOKEN` stays set, so there is no code change to interleave. **Task 6 Step 7 must be modified** or the split is silently discarded and the extra phone edit is incurred anyway. Replacement command block is in the runbook |
+> | 4 — source-IP logging | after Spec 1 | unchanged, and confirmed correct — Task 7's jail filters nginx `access.log`, so app-level logging gates nothing |
+>
+> Also: `/capture/bulk`, `/capture/fix` and `/capture/fix/recent` were **deleted**
+> (`9972b58`) after the Shortcuts were confirmed to call only `/capture` and
+> `/capture/*/fix`. The vhost allowlist needs no location block for them.
+
 Clio-side findings live in `../clio-ai-assitant/docs/INFRA-HANDOFF.md` and are
-owned by a separate session. Only one is order-sensitive:
+owned by a separate session. Original assessment, superseded above where noted:
 
 | Clio finding | Run | Reason |
 |---|---|---|

--- a/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
+++ b/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
@@ -1,0 +1,1986 @@
+# Formava VPS Infrastructure + Datastore Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Provision the Vultr VPS to host Formava alongside Clio — Postgres 16 + pgvector, TLS, systemd supervision, security remediation — and prove the full request chain with a `/health` payload, without deploying any Gradio code.
+
+**Architecture:** nginx terminates TLS for `formava.io` (Next.js BFF on `127.0.0.1:3001`) and `clio.lantzbuilds.com` (Clio on `127.0.0.1:3000`). The Next.js BFF fetches server-side from FastAPI on `127.0.0.1:8000`, which reads Postgres over loopback. No application process binds a public interface; nginx is the only thing ufw exposes. Render stays live and untouched as the fallback throughout.
+
+**Tech Stack:** Ubuntu 24.04, Python 3.12, FastAPI + uvicorn, psycopg 3, Postgres 16 + pgvector 0.6.0, Node 20, Next.js 15 (App Router), nginx 1.24, certbot, systemd, ufw, fail2ban.
+
+**Spec:** `docs/superpowers/specs/2026-07-26-formava-vps-infra-design.md`
+
+---
+
+## Global Constraints
+
+- **Never deploy Gradio to the VPS.** `app/pages/*`, `app/routes.py`, `app/theme.py`, `app/config/state.py` are deleted in Spec 4 and must not be installed or run on the host.
+- **Render stays live and unmodified.** This plan is not a cutover. Do not touch Render config or DNS for `*.onrender.com`.
+- **No schema beyond `CREATE EXTENSION vector`.** Tables, models, and migrations are Spec 2.
+- Python **3.12** (system interpreter, `/usr/bin/python3`). Do not install 3.11.
+- Node **20** (system, `v20.20.2`). `frontend/Dockerfile` currently says `node:18-alpine` — update to 20.
+- Postgres **`postgresql-16`** (`16.14-0ubuntu0.24.04.1`) and **`postgresql-16-pgvector`** (`0.6.0-1`) from Ubuntu repos. No PGDG repo.
+- Postgres tuning, exact values: `shared_buffers=256MB`, `effective_cache_size=1GB`, `max_connections=50`.
+- systemd memory caps, exact values: `formava-api.service` → `MemoryMax=768M`; `formava-web.service` → `MemoryMax=512M`.
+- Bindings: FastAPI `127.0.0.1:8000`, Next.js `127.0.0.1:3001`, Clio `127.0.0.1:3000`, Postgres loopback only. **No process binds `0.0.0.0`.**
+- ufw final state: **22, 80, 443 only.**
+- Secrets live in `/etc/formava/formava.env`, owner `root:root`, mode `0600`. Never rsynced, never committed.
+- Hosts: `formava.io`, `www.formava.io`, `clio.lantzbuilds.com`. **No `api.formava.io`** — FastAPI has no public vhost.
+- `/health` response body, exact shape: `{"db": "ok", "pgvector": "<version>"}`. Failure returns HTTP **503**, never a degraded 200.
+- **No silent fallbacks.** Do not replicate `app/config/database.py:112` (`_create_mock_database`). Missing config or an unreachable database is a startup failure or a 503.
+- CI runs `ruff check app/` and `ruff format --check app/` with no config file, so ruff defaults apply (line length 88). All new `app/` code must pass both.
+- VPS: `144.202.88.7`, user `root`. SSH via `scripts/deploy.sh`-style `sshpass`/key auth already configured in `../clio-ai-assitant/.env`.
+
+## Manual Steps (Human, Not Agent)
+
+Three things an agent cannot do. The plan halts at each until confirmed:
+
+| Where | Action |
+|-------|--------|
+| Task 5 Step 1 | Create DNS A records for `formava.io`, `www.formava.io` → `144.202.88.7` |
+| Task 6 Step 1 | Create DNS A record for `clio.lantzbuilds.com` → `144.202.88.7` |
+| Task 6 Steps 5, 7 | Edit the iOS Shortcut URL, then its bearer token |
+
+## 🛑 Two Irreversible-Order Gates
+
+**Gate A — Task 6 (Clio cutover).** Steps 1→9 must not be reordered. The iOS Shortcut is a client that cannot be updated remotely; closing port 3000 before the Shortcut is verified on HTTPS breaks voice capture *silently* — no error surfaces, transcripts just stop arriving.
+
+**Gate B — Task 8 (SSH hardening).** Verify key-only login in a **second, separate SSH session** before disabling password auth. Getting this wrong locks you out of the host, and recovery requires Vultr's web console.
+
+---
+
+## File Structure
+
+**New Python — the slim API slice.** Deliberately separate from the Gradio monolith's `requirements.txt`, which is dismantled in Specs 2–4.
+
+| File | Responsibility |
+|------|----------------|
+| `app/health/__init__.py` | Package marker (empty) |
+| `app/health/checks.py` | `check_postgres(dsn)` → `PostgresHealth`. Pure DB probe, no HTTP. |
+| `app/health/api.py` | FastAPI app factory + `/health` route. No DB logic. |
+| `requirements-api.txt` | Slim production deps for the VPS venv |
+| `requirements-api-dev.txt` | Adds test/lint tooling |
+| `tests/unit/test_health_api.py` | Route behaviour, DB probe mocked |
+| `tests/integration/test_health_checks.py` | Real Postgres via Compose/CI service |
+| `docker-compose.postgres.yml` | Local Postgres 16 + pgvector for dev and tests |
+
+**Next.js scaffold repair.**
+
+| File | Responsibility |
+|------|----------------|
+| `frontend/package.json` | Manifest — **missing, never committed** |
+| `frontend/package-lock.json` | Lockfile — **missing**; `npm ci` and CI cache depend on it |
+| `frontend/tsconfig.json` | TS config + `@/*` path alias — **missing** |
+| `frontend/src/lib/api/client.ts` | `apiClient` — **missing**, imported by `AuthContext.tsx` |
+| `frontend/src/app/api/health/route.ts` | BFF route handler; server-side fetch of FastAPI `/health` |
+
+**Host provisioning.**
+
+| File | Responsibility |
+|------|----------------|
+| `scripts/vps/provision_postgres.sh` | Idempotent Postgres + pgvector install and tuning |
+| `scripts/vps/formava-api.service` | systemd unit, uvicorn |
+| `scripts/vps/formava-web.service` | systemd unit, Next.js standalone |
+| `scripts/vps/nginx-formava.conf` | `formava.io` vhost |
+| `scripts/vps/nginx-clio.conf` | `clio.lantzbuilds.com` vhost, allowlist + SSE |
+| `scripts/vps/fail2ban-nginx.local` | nginx jails |
+| `scripts/vps/pg_backup.sh` + `.service` + `.timer` | Nightly `pg_dump`, 7-day retention |
+| `scripts/deploy_vps.sh` | rsync → venv → restart, with subcommands |
+| `scripts/vps/verify.sh` | Re-runnable assertion of every §6 exit criterion |
+
+---
+
+## Task 1: FastAPI `/health` slice with real Postgres tests
+
+Pure local work. No VPS access needed. Establishes the ≥80% coverage standard on new code from the outset.
+
+**Files:**
+- Create: `app/health/__init__.py`, `app/health/checks.py`, `app/health/api.py`
+- Create: `requirements-api.txt`, `requirements-api-dev.txt`, `docker-compose.postgres.yml`
+- Create: `tests/integration/__init__.py`, `tests/integration/test_health_checks.py`, `tests/unit/test_health_api.py`
+- Modify: `.github/workflows/ci.yml` (add a Postgres service to `test-backend`)
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces:
+  - `app.health.checks.PostgresHealth` — Pydantic model, fields `db: str`, `pgvector: str`
+  - `app.health.checks.check_postgres(dsn: str) -> PostgresHealth` — raises `psycopg.Error` on failure, never returns a degraded value
+  - `app.health.api.create_app() -> FastAPI` and module-level `app` — uvicorn target is `app.health.api:app`
+  - `/health` → `200 {"db": "ok", "pgvector": "<version>"}` or `503 {"detail": "..."}`
+
+- [ ] **Step 1: Add the dependency files**
+
+`requirements-api.txt` — versions for shared packages match the existing pins in `requirements.txt`:
+
+```
+# Slim production dependencies for the Formava API slice (Spec 1).
+# Deliberately separate from requirements.txt (the Gradio monolith),
+# which is dismantled in Specs 2-4.
+fastapi==0.115.12
+uvicorn[standard]==0.34.2
+pydantic==2.11.5
+python-dotenv==1.1.0
+psycopg[binary]>=3.2,<4
+```
+
+`requirements-api-dev.txt`:
+
+```
+-r requirements-api.txt
+pytest==8.3.4
+httpx==0.28.1
+ruff==0.11.12
+```
+
+- [ ] **Step 2: Add local Postgres for dev and tests**
+
+`docker-compose.postgres.yml`:
+
+```yaml
+# Local Postgres for development and integration tests.
+# The VPS runs Postgres natively under systemd; this is dev-only.
+services:
+  postgres:
+    image: pgvector/pgvector:pg16
+    container_name: formava_postgres
+    environment:
+      POSTGRES_USER: formava
+      POSTGRES_PASSWORD: formava_dev
+      POSTGRES_DB: formava
+    ports:
+      - "5432:5432"
+    volumes:
+      - formava_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U formava -d formava"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  formava_pgdata:
+    name: formava_pgdata
+```
+
+Start it and enable the extension:
+
+```bash
+docker compose -f docker-compose.postgres.yml up -d
+docker exec formava_postgres psql -U formava -d formava -c "CREATE EXTENSION IF NOT EXISTS vector;"
+```
+
+- [ ] **Step 3: Write the failing integration test**
+
+`tests/integration/__init__.py` — empty file.
+
+`tests/integration/test_health_checks.py`:
+
+```python
+import os
+
+import psycopg
+import pytest
+
+from app.health.checks import PostgresHealth, check_postgres
+
+DSN = os.environ.get(
+    "FORMAVA_TEST_DSN",
+    "postgresql://formava:formava_dev@localhost:5432/formava",
+)
+
+
+def test_check_postgres_reports_ok_and_pgvector_version():
+    result = check_postgres(DSN)
+
+    assert isinstance(result, PostgresHealth)
+    assert result.db == "ok"
+    # pgvector reports a semver-ish string such as "0.6.0" or "0.8.0"
+    assert result.pgvector
+    assert result.pgvector[0].isdigit()
+
+
+def test_check_postgres_raises_when_database_unreachable():
+    bad_dsn = "postgresql://formava:formava_dev@localhost:59999/formava"
+
+    # Must raise, never return a degraded value. No silent fallback.
+    with pytest.raises(psycopg.Error):
+        check_postgres(bad_dsn)
+```
+
+- [ ] **Step 4: Run it to confirm it fails**
+
+Run: `python -m pytest tests/integration/test_health_checks.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.health'`
+
+- [ ] **Step 5: Implement the probe**
+
+`app/health/__init__.py` — empty file.
+
+`app/health/checks.py`:
+
+```python
+"""Database health probes for the Formava API.
+
+Deliberately has no fallback behaviour. An unreachable database raises,
+so callers surface a 503 rather than reporting healthy while serving an
+empty datastore (contrast app/config/database.py:112).
+"""
+
+import psycopg
+from pydantic import BaseModel
+
+
+class PostgresHealth(BaseModel):
+    """Result of a successful Postgres probe."""
+
+    db: str
+    pgvector: str
+
+
+def check_postgres(dsn: str) -> PostgresHealth:
+    """Verify Postgres is reachable and the pgvector extension is installed.
+
+    Raises:
+        psycopg.Error: connection failed, or pgvector is not installed.
+    """
+    with psycopg.connect(dsn, connect_timeout=5) as conn:
+        with conn.cursor() as cur:
+            cur.execute("SELECT extversion FROM pg_extension WHERE extname = 'vector'")
+            row = cur.fetchone()
+
+    if row is None:
+        raise psycopg.OperationalError(
+            "pgvector extension is not installed in this database"
+        )
+
+    return PostgresHealth(db="ok", pgvector=row[0])
+```
+
+- [ ] **Step 6: Run the integration test to confirm it passes**
+
+Run: `python -m pytest tests/integration/test_health_checks.py -v`
+Expected: 2 passed
+
+- [ ] **Step 7: Write the failing API test**
+
+`tests/unit/test_health_api.py`:
+
+```python
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+
+from app.health.api import create_app
+from app.health.checks import PostgresHealth
+
+
+@pytest.fixture
+def client_with_healthy_db(monkeypatch):
+    def fake_check(dsn: str) -> PostgresHealth:
+        return PostgresHealth(db="ok", pgvector="0.6.0")
+
+    monkeypatch.setattr("app.health.api.check_postgres", fake_check)
+    return TestClient(create_app(dsn="postgresql://unused"))
+
+
+@pytest.fixture
+def client_with_broken_db(monkeypatch):
+    def fake_check(dsn: str) -> PostgresHealth:
+        raise psycopg.OperationalError("connection refused")
+
+    monkeypatch.setattr("app.health.api.check_postgres", fake_check)
+    return TestClient(
+        create_app(dsn="postgresql://unused"), raise_server_exceptions=False
+    )
+
+
+def test_health_returns_exact_spec_shape(client_with_healthy_db):
+    response = client_with_healthy_db.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"db": "ok", "pgvector": "0.6.0"}
+
+
+def test_health_returns_503_when_database_unreachable(client_with_broken_db):
+    response = client_with_broken_db.get("/health")
+
+    # Must fail loudly. A degraded 200 would defeat the purpose.
+    assert response.status_code == 503
+    assert "connection refused" in response.json()["detail"]
+
+
+def test_create_app_requires_a_dsn():
+    with pytest.raises(ValueError, match="DSN"):
+        create_app(dsn="")
+```
+
+- [ ] **Step 8: Run it to confirm it fails**
+
+Run: `python -m pytest tests/unit/test_health_api.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named 'app.health.api'`
+
+- [ ] **Step 9: Implement the API**
+
+`app/health/api.py`:
+
+```python
+"""Thin-slice FastAPI application for Spec 1.
+
+Exists to prove the request chain TLS -> nginx -> Next.js -> FastAPI ->
+Postgres before any real application code is migrated. Serves exactly one
+route.
+"""
+
+import logging
+import os
+
+import psycopg
+from fastapi import FastAPI, HTTPException
+
+from app.health.checks import check_postgres
+
+logger = logging.getLogger(__name__)
+
+
+def create_app(dsn: str | None = None) -> FastAPI:
+    """Build the health application.
+
+    Args:
+        dsn: Postgres connection string. Falls back to FORMAVA_DATABASE_URL.
+
+    Raises:
+        ValueError: no DSN supplied and none in the environment. Fails at
+            startup rather than serving a broken app.
+    """
+    resolved = dsn if dsn is not None else os.environ.get("FORMAVA_DATABASE_URL", "")
+    if not resolved:
+        raise ValueError(
+            "No Postgres DSN: pass dsn= or set FORMAVA_DATABASE_URL. "
+            "Refusing to start without one."
+        )
+
+    application = FastAPI(title="Formava API", version="0.1.0")
+
+    @application.get("/health")
+    def health() -> dict[str, str]:
+        try:
+            result = check_postgres(resolved)
+        except psycopg.Error as exc:
+            logger.error("Health check failed: %s", exc)
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+        return result.model_dump()
+
+    return application
+
+
+app = create_app()
+```
+
+- [ ] **Step 10: Run the full suite and the linters**
+
+```bash
+export FORMAVA_DATABASE_URL="postgresql://formava:formava_dev@localhost:5432/formava"
+python -m pytest tests/ -v
+ruff check app/
+ruff format --check app/
+```
+
+Expected: all tests pass (including the pre-existing `test_hevy_api.py`), both ruff commands clean.
+
+- [ ] **Step 11: Add Postgres to CI so the integration test can run**
+
+In `.github/workflows/ci.yml`, inside the `test-backend` job, add a `services:` block directly after `runs-on: ubuntu-latest` and before `strategy:`:
+
+```yaml
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: formava
+          POSTGRES_PASSWORD: formava_dev
+          POSTGRES_DB: formava
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U formava -d formava"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+```
+
+Then change the `Install dependencies` step to also install the API dev deps, and add an extension-enabling step before `Run tests`:
+
+```yaml
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-api-dev.txt
+
+    - name: Enable pgvector
+      run: |
+        PGPASSWORD=formava_dev psql -h localhost -U formava -d formava \
+          -c "CREATE EXTENSION IF NOT EXISTS vector;"
+
+    - name: Run tests
+      env:
+        FORMAVA_DATABASE_URL: postgresql://formava:formava_dev@localhost:5432/formava
+        FORMAVA_TEST_DSN: postgresql://formava:formava_dev@localhost:5432/formava
+      run: |
+        pytest tests/ -v
+```
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add app/health requirements-api.txt requirements-api-dev.txt \
+        docker-compose.postgres.yml tests/unit/test_health_api.py \
+        tests/integration .github/workflows/ci.yml
+git commit -m "feat: add FastAPI /health slice with pgvector probe
+
+Thin-slice payload for Spec 1. Fails loudly with 503 rather than
+reporting healthy on an unreachable database. Slim requirements-api.txt
+keeps the VPS venv independent of the Gradio monolith's dependencies."
+```
+
+---
+
+## Task 2: Repair the Next.js scaffold and add the BFF health route
+
+The scaffold cannot build today: `package.json`, `package-lock.json`, `tsconfig.json`, and `src/lib/api/client.ts` are all absent, and `AuthContext.tsx` imports that missing module. `git log --all -- frontend/package.json` is empty, so the manifest was never committed.
+
+**Files:**
+- Create: `frontend/package.json`, `frontend/tsconfig.json`, `frontend/src/lib/api/client.ts`, `frontend/src/app/api/health/route.ts`
+- Generate: `frontend/package-lock.json`, `frontend/next-env.d.ts`
+- Modify: `frontend/next.config.ts`, `frontend/Dockerfile`
+
+**Interfaces:**
+- Consumes: `app.health.api` `/health` contract from Task 1 — `200 {"db": string, "pgvector": string}` or `503 {"detail": string}`.
+- Produces:
+  - `frontend/src/lib/api/client.ts` exports `apiClient` and `ApiResponse<T>`
+  - `apiClient.login(username: string, password: string): Promise<ApiResponse<{ user: User }>>`
+  - `apiClient.register(userData: RegisterForm): Promise<ApiResponse<{ user: User }>>`
+  - `apiClient.logout(): Promise<void>`
+  - `apiClient.health(): Promise<ApiResponse<{ db: string; pgvector: string }>>`
+  - `GET /api/health` on the Next.js server, proxying FastAPI server-side
+  - `next.config.ts` sets `output: "standalone"`, required by `formava-web.service`
+
+- [ ] **Step 1: Create the manifest**
+
+Tailwind v4 is already implied by `src/app/globals.css` (`@import "tailwindcss"`) and `postcss.config.mjs` (`@tailwindcss/postcss`), so those deps are required, not optional.
+
+`frontend/package.json`:
+
+```json
+{
+  "name": "formava-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "next": "^15.1.6",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.2.0",
+    "@tailwindcss/postcss": "^4.0.0",
+    "@types/node": "^20.17.16",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
+    "eslint": "^9.19.0",
+    "eslint-config-next": "^15.1.6",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^5.7.3"
+  }
+}
+```
+
+- [ ] **Step 2: Create the TypeScript config**
+
+The `@/*` alias is what every existing import relies on.
+
+`frontend/tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}
+```
+
+- [ ] **Step 3: Install and confirm the build fails on the missing module**
+
+```bash
+cd frontend && npm install
+npx tsc --noEmit
+```
+
+Expected: FAIL — `Cannot find module '@/lib/api/client'` from `src/contexts/AuthContext.tsx`. This confirms the gap before filling it.
+
+- [ ] **Step 4: Create the API client**
+
+Signatures are dictated by existing calls in `AuthContext.tsx:55,83,107`. Auth methods throw deliberately — auth is Spec 4, and a throwing stub is honest where a fake success would be misleading.
+
+`frontend/src/lib/api/client.ts`:
+
+```typescript
+import type { RegisterForm, User } from '@/types';
+
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+export interface HealthPayload {
+  db: string;
+  pgvector: string;
+}
+
+/**
+ * Base URL for the FastAPI backend.
+ *
+ * Server-side only. The browser never calls FastAPI directly under the BFF
+ * pattern -- it calls Next.js route handlers, which call FastAPI.
+ */
+const API_BASE_URL = process.env.FORMAVA_API_URL ?? 'http://127.0.0.1:8000';
+
+class ApiClient {
+  async health(): Promise<ApiResponse<HealthPayload>> {
+    try {
+      const res = await fetch(`${API_BASE_URL}/health`, {
+        cache: 'no-store',
+      });
+
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { detail?: string };
+        return { success: false, error: body.detail ?? `HTTP ${res.status}` };
+      }
+
+      return { success: true, data: (await res.json()) as HealthPayload };
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      };
+    }
+  }
+
+  // ---- Auth: implemented in Spec 4 (REST API + Next.js BFF) ----
+  // These throw rather than returning a fake success so that any premature
+  // use fails loudly. Signatures match the existing calls in AuthContext.
+
+  async login(
+    _username: string,
+    _password: string
+  ): Promise<ApiResponse<{ user: User }>> {
+    throw new Error('apiClient.login is not implemented until Spec 4');
+  }
+
+  async register(_userData: RegisterForm): Promise<ApiResponse<{ user: User }>> {
+    throw new Error('apiClient.register is not implemented until Spec 4');
+  }
+
+  async logout(): Promise<void> {
+    throw new Error('apiClient.logout is not implemented until Spec 4');
+  }
+}
+
+export const apiClient = new ApiClient();
+```
+
+- [ ] **Step 5: Add the BFF route handler**
+
+This is the piece that proves the chain. It runs on the Next.js server, not the browser.
+
+`frontend/src/app/api/health/route.ts`:
+
+```typescript
+import { NextResponse } from 'next/server';
+
+import { apiClient } from '@/lib/api/client';
+
+/**
+ * BFF health route. Fetches FastAPI server-side over loopback and relays the
+ * result, proving TLS -> nginx -> Next.js -> FastAPI -> Postgres end to end.
+ */
+export async function GET() {
+  const result = await apiClient.health();
+
+  if (!result.success || !result.data) {
+    return NextResponse.json(
+      { error: result.error ?? 'health check failed' },
+      { status: 503 }
+    );
+  }
+
+  return NextResponse.json(result.data, { status: 200 });
+}
+```
+
+- [ ] **Step 6: Enable standalone output**
+
+`formava-web.service` runs `node server.js`, which only exists with standalone output.
+
+`frontend/next.config.ts`:
+
+```typescript
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {
+  // Emits .next/standalone with a self-contained server.js — required by
+  // formava-web.service and by the multi-stage Dockerfile.
+  output: "standalone",
+};
+
+export default nextConfig;
+```
+
+- [ ] **Step 7: Update the Dockerfile to Node 20**
+
+In `frontend/Dockerfile`, change the base image line:
+
+```dockerfile
+FROM node:20-alpine AS base
+```
+
+- [ ] **Step 8: Verify the build, types, and lint all pass**
+
+```bash
+cd frontend
+npx tsc --noEmit
+npm run lint
+npm run build
+ls .next/standalone/server.js
+```
+
+Expected: `tsc` clean, lint clean, build succeeds, `server.js` present.
+
+- [ ] **Step 9: Verify the chain locally**
+
+With Postgres from Task 1 up, in two terminals:
+
+```bash
+# terminal 1
+export FORMAVA_DATABASE_URL="postgresql://formava:formava_dev@localhost:5432/formava"
+python -m uvicorn app.health.api:app --host 127.0.0.1 --port 8000
+
+# terminal 2
+cd frontend && FORMAVA_API_URL=http://127.0.0.1:8000 npm run dev
+```
+
+Then: `curl -s http://localhost:3000/api/health`
+Expected: `{"db":"ok","pgvector":"0.6.0"}` (version may differ)
+
+Now stop uvicorn and re-run the curl.
+Expected: HTTP 503 with an `error` field — confirming failures propagate rather than being swallowed.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add frontend/package.json frontend/package-lock.json frontend/tsconfig.json \
+        frontend/next-env.d.ts frontend/next.config.ts frontend/Dockerfile \
+        frontend/src/lib frontend/src/app/api
+git commit -m "fix: repair Next.js scaffold and add BFF health route
+
+package.json, package-lock.json, and tsconfig.json were never committed,
+and AuthContext imported a non-existent @/lib/api/client, so the scaffold
+could not build. Adds the manifest (Tailwind v4, Node 20), the TS config
+providing the @/* alias, and the API client. Auth methods throw until
+Spec 4 rather than returning fake success. Enables standalone output for
+formava-web.service."
+```
+
+---
+
+## Task 3: Provision Postgres 16 + pgvector on the VPS
+
+**Files:**
+- Create: `scripts/vps/provision_postgres.sh`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: a `formava` database owned by role `formava` with the `vector` extension, listening on loopback only. DSN shape: `postgresql://formava:<password>@127.0.0.1:5432/formava`.
+
+- [ ] **Step 1: Write the provisioning script**
+
+`scripts/vps/provision_postgres.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Provision Postgres 16 + pgvector for Formava. Idempotent: safe to re-run.
+#
+# Usage: ./provision_postgres.sh <formava_db_password>
+set -euo pipefail
+
+DB_PASSWORD="${1:?Usage: $0 <formava_db_password>}"
+DB_NAME="formava"
+DB_USER="formava"
+PG_VERSION="16"
+PG_CONF="/etc/postgresql/${PG_VERSION}/main/postgresql.conf"
+
+log() { echo "[provision-postgres] $*"; }
+
+log "Installing packages from Ubuntu repositories..."
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y --no-install-recommends \
+    "postgresql-${PG_VERSION}" \
+    "postgresql-${PG_VERSION}-pgvector"
+
+log "Ensuring role ${DB_USER} exists..."
+if ! sudo -u postgres psql -tAc \
+    "SELECT 1 FROM pg_roles WHERE rolname='${DB_USER}'" | grep -q 1; then
+    sudo -u postgres psql -c \
+        "CREATE ROLE ${DB_USER} LOGIN PASSWORD '${DB_PASSWORD}';"
+else
+    log "Role exists; syncing password."
+    sudo -u postgres psql -c \
+        "ALTER ROLE ${DB_USER} WITH LOGIN PASSWORD '${DB_PASSWORD}';"
+fi
+
+log "Ensuring database ${DB_NAME} exists..."
+if ! sudo -u postgres psql -tAc \
+    "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" | grep -q 1; then
+    sudo -u postgres createdb -O "${DB_USER}" "${DB_NAME}"
+fi
+
+log "Enabling pgvector in ${DB_NAME}..."
+sudo -u postgres psql -d "${DB_NAME}" -c "CREATE EXTENSION IF NOT EXISTS vector;"
+
+log "Applying tuning for 2 vCPU / 3.8 GB..."
+# Values are fixed by the spec's memory budget. Appended in a marked block so
+# re-runs replace rather than accumulate.
+MARKER="# --- formava tuning (managed) ---"
+if grep -qF "${MARKER}" "${PG_CONF}"; then
+    sed -i "/${MARKER}/,\$d" "${PG_CONF}"
+fi
+cat >> "${PG_CONF}" <<EOF
+${MARKER}
+listen_addresses = 'localhost'
+shared_buffers = 256MB
+effective_cache_size = 1GB
+max_connections = 50
+password_encryption = scram-sha-256
+EOF
+
+log "Restarting Postgres..."
+systemctl restart postgresql
+systemctl enable postgresql
+
+log "Verifying..."
+sudo -u postgres psql -d "${DB_NAME}" -tAc \
+    "SELECT extversion FROM pg_extension WHERE extname='vector'"
+ss -tlnp | grep 5432 || true
+
+log "Done."
+```
+
+- [ ] **Step 2: Make it executable and copy it to the VPS**
+
+```bash
+chmod +x scripts/vps/provision_postgres.sh
+scp scripts/vps/provision_postgres.sh root@144.202.88.7:/root/
+```
+
+- [ ] **Step 3: Generate a password and run it**
+
+```bash
+ssh root@144.202.88.7
+DB_PW="$(openssl rand -base64 24 | tr -d '/+=' | head -c 32)"
+echo "SAVE THIS: ${DB_PW}"
+/root/provision_postgres.sh "${DB_PW}"
+```
+
+Expected: script completes; final output shows a pgvector version (e.g. `0.6.0`) and a listener on `127.0.0.1:5432`.
+
+- [ ] **Step 4: Verify loopback-only binding and idempotency**
+
+```bash
+ssh root@144.202.88.7 '
+  ss -tlnp | grep 5432
+  PGPASSWORD="'"${DB_PW}"'" psql -h 127.0.0.1 -U formava -d formava \
+    -tAc "SELECT extversion FROM pg_extension WHERE extname=\"vector\""
+  /root/provision_postgres.sh "'"${DB_PW}"'"
+'
+```
+
+Expected: listener shows `127.0.0.1:5432` and **not** `0.0.0.0:5432`; psql returns the version; the second run succeeds without errors or duplicated config (`grep -c "formava tuning" /etc/postgresql/16/main/postgresql.conf` returns `1`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/vps/provision_postgres.sh
+git commit -m "feat: add idempotent Postgres 16 + pgvector provisioning script
+
+Installs from Ubuntu repos (no PGDG), binds loopback only, applies the
+spec's tuning values for 2 vCPU / 3.8 GB in a marked block so re-runs
+replace rather than accumulate."
+```
+
+---
+
+## Task 4: systemd units and the deploy script
+
+**Files:**
+- Create: `scripts/vps/formava-api.service`, `scripts/vps/formava-web.service`, `scripts/deploy_vps.sh`
+
+**Interfaces:**
+- Consumes: `app.health.api:app` (Task 1); `frontend/.next/standalone/server.js` (Task 2); Postgres DSN (Task 3).
+- Produces: `formava-api.service` on `127.0.0.1:8000`, `formava-web.service` on `127.0.0.1:3001`, both reading `/etc/formava/formava.env`. `scripts/deploy_vps.sh` with subcommands `deploy|sync|install|build|restart|logs|status`.
+
+- [ ] **Step 1: Write the API unit**
+
+`scripts/vps/formava-api.service`:
+
+```ini
+[Unit]
+Description=Formava API (FastAPI)
+After=network.target postgresql.service
+Requires=postgresql.service
+StartLimitBurst=5
+StartLimitIntervalSec=60
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/formava
+EnvironmentFile=/etc/formava/formava.env
+ExecStart=/opt/formava/.venv/bin/uvicorn app.health.api:app \
+    --host 127.0.0.1 --port 8000
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=formava-api
+
+# Cap ~3x measured steady state. Combined with formava-web (512M) and
+# Postgres (320M) this stays well inside 3.8 GB, so a runaway here is killed
+# by the kernel before it can pressure clio.service into its
+# StartLimitBurst=5 permanent-failure state.
+MemoryMax=768M
+
+[Install]
+WantedBy=multi-user.target
+```
+
+- [ ] **Step 2: Write the web unit**
+
+`scripts/vps/formava-web.service`:
+
+```ini
+[Unit]
+Description=Formava Web (Next.js BFF)
+After=network.target formava-api.service
+StartLimitBurst=5
+StartLimitIntervalSec=60
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/formava/frontend/.next/standalone
+EnvironmentFile=/etc/formava/formava.env
+Environment=NODE_ENV=production
+Environment=PORT=3001
+Environment=HOSTNAME=127.0.0.1
+ExecStart=/usr/bin/node server.js
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=formava-web
+
+MemoryMax=512M
+
+[Install]
+WantedBy=multi-user.target
+```
+
+- [ ] **Step 3: Write the deploy script**
+
+`scripts/deploy_vps.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Deploy Formava to the VPS. Modelled on Clio's scripts/deploy.sh.
+#
+# Usage:
+#   ./scripts/deploy_vps.sh            # build + sync + install + restart
+#   ./scripts/deploy_vps.sh sync       # rsync only
+#   ./scripts/deploy_vps.sh restart    # restart both units
+#   ./scripts/deploy_vps.sh logs api   # follow logs (api|web)
+#   ./scripts/deploy_vps.sh status
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+VPS_HOST="${VPS_HOST:-144.202.88.7}"
+VPS_USER="${VPS_USER:-root}"
+APP_PATH="${APP_PATH:-/opt/formava}"
+
+SSH="ssh ${VPS_USER}@${VPS_HOST}"
+
+GREEN='\033[0;32m'; NC='\033[0m'
+log() { echo -e "${GREEN}[deploy]${NC} $1"; }
+
+build_frontend() {
+    log "Building Next.js standalone bundle locally..."
+    # Built here, not on the host: `next build` wants 1.5-2 GB and would
+    # needlessly contend with Clio.
+    (cd "$PROJECT_DIR/frontend" && npm ci && npm run build)
+}
+
+sync_files() {
+    log "Syncing to ${VPS_HOST}:${APP_PATH}..."
+    $SSH "mkdir -p ${APP_PATH}"
+
+    # Gradio is deliberately excluded -- it must never reach the VPS.
+    rsync -avz --delete \
+        --exclude '.git' \
+        --exclude '.venv' \
+        --exclude 'node_modules' \
+        --exclude '__pycache__' \
+        --exclude '.env' \
+        --exclude '.next/cache' \
+        --exclude 'app/pages' \
+        --exclude 'app/routes.py' \
+        --exclude 'app/theme.py' \
+        --exclude 'app/config/state.py' \
+        --exclude 'tests' \
+        --exclude '*.log' \
+        --exclude '.DS_Store' \
+        "$PROJECT_DIR/" "${VPS_USER}@${VPS_HOST}:${APP_PATH}/"
+}
+
+install_deps() {
+    log "Installing Python dependencies in the venv..."
+    $SSH "cd ${APP_PATH} && \
+        (test -d .venv || python3 -m venv .venv) && \
+        .venv/bin/pip install --upgrade pip -q && \
+        .venv/bin/pip install -r requirements-api.txt -q"
+}
+
+install_units() {
+    log "Installing systemd units..."
+    $SSH "cp ${APP_PATH}/scripts/vps/formava-api.service /etc/systemd/system/ && \
+          cp ${APP_PATH}/scripts/vps/formava-web.service /etc/systemd/system/ && \
+          systemctl daemon-reload && \
+          systemctl enable formava-api formava-web"
+}
+
+restart_services() {
+    log "Restarting services..."
+    $SSH "systemctl restart formava-api formava-web"
+    sleep 3
+    $SSH "systemctl is-active formava-api formava-web"
+}
+
+case "${1:-deploy}" in
+    deploy)  build_frontend; sync_files; install_deps; install_units; restart_services ;;
+    build)   build_frontend ;;
+    sync)    sync_files ;;
+    install) install_deps; install_units ;;
+    restart) restart_services ;;
+    logs)    $SSH "journalctl -u formava-${2:-api} -f --no-pager -n 50" ;;
+    status)  $SSH "systemctl status formava-api formava-web --no-pager" ;;
+    *)       echo "Usage: $0 {deploy|build|sync|install|restart|logs|status}"; exit 1 ;;
+esac
+
+log "Done."
+```
+
+- [ ] **Step 4: Create the secrets file on the VPS**
+
+Never rsynced, never committed. Use the `DB_PW` from Task 3 Step 3.
+
+```bash
+ssh root@144.202.88.7 '
+  mkdir -p /etc/formava
+  cat > /etc/formava/formava.env <<EOF
+FORMAVA_DATABASE_URL=postgresql://formava:REPLACE_WITH_DB_PW@127.0.0.1:5432/formava
+FORMAVA_API_URL=http://127.0.0.1:8000
+EOF
+  chown root:root /etc/formava/formava.env
+  chmod 0600 /etc/formava/formava.env
+  ls -la /etc/formava/formava.env
+'
+```
+
+Expected: `-rw------- 1 root root`. Replace `REPLACE_WITH_DB_PW` with the real password.
+
+- [ ] **Step 5: Deploy**
+
+```bash
+chmod +x scripts/deploy_vps.sh
+./scripts/deploy_vps.sh deploy
+```
+
+Expected: build succeeds, rsync completes, both units report `active`.
+
+- [ ] **Step 6: Verify both services and the memory caps**
+
+```bash
+ssh root@144.202.88.7 '
+  curl -s http://127.0.0.1:8000/health; echo
+  curl -s http://127.0.0.1:3001/api/health; echo
+  ss -tlnp | grep -E ":8000|:3001"
+  systemctl show formava-api -p MemoryMax
+  systemctl show formava-web -p MemoryMax
+  free -h | head -2
+'
+```
+
+Expected: both curls return `{"db":"ok","pgvector":"..."}`; both listeners on `127.0.0.1` only; `MemoryMax=805306368` and `536870912`; total memory use under 1.5 GB.
+
+- [ ] **Step 7: Confirm Gradio was not deployed**
+
+```bash
+ssh root@144.202.88.7 'ls /opt/formava/app/pages /opt/formava/app/routes.py 2>&1'
+```
+
+Expected: "No such file or directory" for both.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add scripts/vps/formava-api.service scripts/vps/formava-web.service \
+        scripts/deploy_vps.sh
+git commit -m "feat: add systemd units and VPS deploy script
+
+MemoryMax caps (768M api, 512M web) keep a Formava runaway from pressuring
+clio.service into StartLimitBurst=5 permanent failure. Next.js is built
+locally rather than on the host, and the rsync excludes the Gradio layer
+so it can never reach the VPS."
+```
+
+---
+
+## Task 5: nginx vhost and TLS for formava.io
+
+**Files:**
+- Create: `scripts/vps/nginx-formava.conf`
+
+**Interfaces:**
+- Consumes: `formava-web.service` on `127.0.0.1:3001` (Task 4).
+- Produces: `https://formava.io` serving the Next.js app; `https://formava.io/api/health` proving the chain; `www` redirecting to apex.
+
+- [ ] **Step 1: 🛑 HUMAN — create DNS records, then verify propagation**
+
+Create two A records at your registrar:
+
+| Name | Type | Value |
+|------|------|-------|
+| `formava.io` | A | `144.202.88.7` |
+| `www.formava.io` | A | `144.202.88.7` |
+
+Then verify **before** running certbot — an HTTP-01 challenge against a stale record fails in a way that reads like an nginx misconfiguration:
+
+```bash
+dig +short formava.io
+dig +short www.formava.io
+```
+
+Expected: both output `144.202.88.7`. Do not proceed until they do.
+
+- [ ] **Step 2: Write the vhost (HTTP only, for the ACME challenge)**
+
+certbot rewrites this file to add TLS. Start with port 80 so the challenge can succeed.
+
+`scripts/vps/nginx-formava.conf`:
+
+```nginx
+# Formava — Next.js BFF. certbot injects the TLS listener and redirect.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name formava.io www.formava.io;
+
+    client_max_body_size 2m;
+
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    location / {
+        proxy_pass http://127.0.0.1:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        "upgrade";
+    }
+}
+```
+
+- [ ] **Step 3: Install it and issue the certificate**
+
+```bash
+scp scripts/vps/nginx-formava.conf root@144.202.88.7:/etc/nginx/sites-available/formava
+ssh root@144.202.88.7 '
+  apt-get install -y --no-install-recommends certbot python3-certbot-nginx
+  ln -sf /etc/nginx/sites-available/formava /etc/nginx/sites-enabled/formava
+  nginx -t && systemctl reload nginx
+  certbot --nginx -d formava.io -d www.formava.io \
+      --non-interactive --agree-tos -m lantz@gocascade.ai --redirect
+'
+```
+
+Expected: certbot reports successful issuance and modifies the vhost to listen on 443 with a redirect from 80.
+
+- [ ] **Step 4: Add HSTS**
+
+Deliberately without `includeSubDomains` or `preload`, so this certificate makes no commitments for other hosts. `preload` in particular is hard to reverse.
+
+```bash
+ssh root@144.202.88.7 '
+  sed -i "/server_name formava.io www.formava.io;/a \\    add_header Strict-Transport-Security \"max-age=31536000\" always;" \
+      /etc/nginx/sites-available/formava
+  nginx -t && systemctl reload nginx
+'
+```
+
+- [ ] **Step 5: Verify the full chain over TLS**
+
+```bash
+curl -sI http://formava.io | head -1
+curl -s https://formava.io/api/health; echo
+curl -sI https://formava.io | grep -i strict-transport
+curl -sI https://www.formava.io | head -1
+ssh root@144.202.88.7 'certbot renew --dry-run 2>&1 | tail -3'
+```
+
+Expected: HTTP returns `301`; `/api/health` returns `{"db":"ok","pgvector":"..."}` over HTTPS; the HSTS header is present; `www` redirects; the renewal dry run succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/vps/nginx-formava.conf
+git commit -m "feat: add formava.io nginx vhost with TLS
+
+HSTS without includeSubDomains or preload, so this cert constrains no
+other hosts. Proxies to the Next.js BFF on loopback; FastAPI gets no
+public vhost."
+```
+
+---
+
+## Task 6: 🛑 Clio cutover — ordered, do not reorder
+
+**Gate A.** The iOS Shortcut cannot be updated remotely. Closing port 3000 before the Shortcut is verified on HTTPS breaks voice capture **silently**. Steps run strictly in order, and Step 9 is the point of no return.
+
+**Files:**
+- Create: `scripts/vps/nginx-clio.conf`
+
+**Interfaces:**
+- Consumes: Clio on port 3000 (currently `0.0.0.0`, ends on `127.0.0.1`).
+- Produces: `https://clio.lantzbuilds.com` publishing exactly `POST /capture`, `POST /capture/<id>/fix`, `GET /health`, and `/api/sessions/*`. Everything else returns 404 at nginx.
+
+- [ ] **Step 1: 🛑 HUMAN — create the DNS record and verify**
+
+| Name | Type | Value |
+|------|------|-------|
+| `clio.lantzbuilds.com` | A | `144.202.88.7` |
+
+```bash
+dig +short clio.lantzbuilds.com
+```
+
+Expected: `144.202.88.7`. Do not proceed until it resolves.
+
+- [ ] **Step 2: Write the allowlist vhost**
+
+This is a security control, not tidiness. `/api/sessions/*` drives an Anthropic-backed orchestrator with vault filesystem access, and one token guards everything, so bounding reachable paths bounds a leaked credential.
+
+`scripts/vps/nginx-clio.conf`:
+
+```nginx
+# Clio — allowlist vhost. Only paths with a known caller are published.
+# /status, /capture/bulk, /capture/fix, /capture/fix/recent stay closed.
+limit_req_zone $binary_remote_addr zone=capture:1m  rate=10r/m;
+limit_req_zone $binary_remote_addr zone=sessions:1m rate=60r/m;
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name clio.lantzbuilds.com;
+
+    client_max_body_size 64k;
+
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer" always;
+
+    # iOS Shortcut — new capture
+    location = /capture {
+        limit_except POST { deny all; }
+        limit_req zone=capture burst=5 nodelay;
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host            $host;
+        proxy_set_header X-Real-IP       $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # iOS Shortcut — correct an existing capture by id.
+    # Regex because an exact match cannot cover a path parameter. Anchored to
+    # exactly three segments so /capture/fix and /capture/fix/recent do NOT
+    # match and stay closed. nginx evaluates regex locations before plain
+    # prefix matches, so `location /` never sees this.
+    location ~ ^/capture/[^/]+/fix$ {
+        limit_except POST { deny all; }
+        limit_req zone=capture burst=5 nodelay;
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host            $host;
+        proxy_set_header X-Real-IP       $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # CLI connection validation
+    location = /health {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+    }
+
+    # CLI session control. SSE settings are load-bearing: with nginx's
+    # default proxy_buffering the chat stream is buffered and typewriter
+    # rendering breaks, and the default 60s read timeout severs long turns.
+    location /api/sessions {
+        limit_req zone=sessions burst=20 nodelay;
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host            $host;
+        proxy_set_header X-Real-IP       $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Connection      '';
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 120s;
+    }
+
+    location / { return 404; }
+}
+```
+
+- [ ] **Step 3: Install and issue the certificate**
+
+Clio stays on `0.0.0.0:3000` for now, so the old direct path and the new HTTPS path work simultaneously.
+
+```bash
+scp scripts/vps/nginx-clio.conf root@144.202.88.7:/etc/nginx/sites-available/clio
+ssh root@144.202.88.7 '
+  ln -sf /etc/nginx/sites-available/clio /etc/nginx/sites-enabled/clio
+  nginx -t && systemctl reload nginx
+  certbot --nginx -d clio.lantzbuilds.com \
+      --non-interactive --agree-tos -m lantz@gocascade.ai --redirect
+'
+```
+
+- [ ] **Step 4: Verify the allowlist before touching the Shortcut**
+
+Read `CAPTURE_API_TOKEN` from `/opt/clio/.env` on the host and export it locally as `TOKEN`.
+
+```bash
+# Published paths reach Clio
+curl -s -o /dev/null -w "capture     %{http_code}\n" -X POST \
+  -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  -d '{"text":"allowlist probe"}' https://clio.lantzbuilds.com/capture
+curl -s -o /dev/null -w "health      %{http_code}\n" \
+  https://clio.lantzbuilds.com/health
+
+# Closed paths 404 at nginx even WITH a valid token -- the property being relied on
+for p in /status /capture/bulk /capture/fix /capture/fix/recent /v404/exec; do
+  printf "%-22s " "$p"
+  curl -s -o /dev/null -w "%{http_code}\n" \
+    -H "Authorization: Bearer $TOKEN" "https://clio.lantzbuilds.com$p"
+done
+
+# Method restriction
+curl -s -o /dev/null -w "GET /capture %{http_code}\n" \
+  -H "Authorization: Bearer $TOKEN" https://clio.lantzbuilds.com/capture
+```
+
+Expected: `capture` 200/201; `health` 200; all five closed paths `404`; `GET /capture` `403`.
+
+- [ ] **Step 5: 🛑 HUMAN — update the Shortcut URL**
+
+On the phone, edit the Clio Shortcut's URL action:
+
+```
+http://144.202.88.7:3000/capture   →   https://clio.lantzbuilds.com/capture
+```
+
+Do the same for the second Shortcut that calls `/capture/<id>/fix`.
+
+- [ ] **Step 6: Verify a real capture end to end**
+
+Run both Shortcuts from the phone, then:
+
+```bash
+ssh root@144.202.88.7 '
+  tail -20 /var/log/nginx/access.log | grep capture
+  journalctl -u clio --no-pager -n 20 | tail -10
+'
+```
+
+Expected: nginx access log shows `POST /capture` (and the fix route) with **your phone's source IP** — the observability gap is now closed — and Clio's log shows the capture arriving. Confirm the dictated text landed in the inbox.
+
+- [ ] **Step 7: 🛑 HUMAN — rotate the token, then update the Shortcuts again**
+
+The current token was exposed in plaintext during assessment.
+
+```bash
+ssh root@144.202.88.7 '
+  NEW="$(openssl rand -hex 32)"
+  echo "NEW TOKEN: ${NEW}"
+  sed -i "s/^CAPTURE_API_TOKEN=.*/CAPTURE_API_TOKEN=${NEW}/" /opt/clio/.env
+  systemctl restart clio
+  sleep 3 && systemctl is-active clio
+'
+```
+
+Then on the phone, update the `Authorization: Bearer <token>` header in **both** Shortcuts, and run `clio config set-token <new>` for the CLI.
+
+- [ ] **Step 8: Verify captures and CLI still work on the new token**
+
+Run a Shortcut capture, and point the CLI at HTTPS:
+
+```bash
+clio config set-url https://clio.lantzbuilds.com
+clio config set-token <new-token>
+# exercise a session, including a streaming chat, to confirm SSE works
+```
+
+Expected: capture lands; CLI connects; **chat streams incrementally rather than arriving all at once** — that confirms `proxy_buffering off` is effective.
+
+- [ ] **Step 9: 🛑 POINT OF NO RETURN — close port 3000 at the firewall**
+
+Only proceed once Step 8 passed. This kills the plaintext path.
+
+**Clio cannot currently bind to loopback.** `src/api/capture.ts:419` calls
+`app.listen(config.port, () => {...})` with **no host argument**, so Express binds
+`0.0.0.0`, and no `CAPTURE_API_HOST` environment variable exists. Binding to
+loopback requires a one-line source change:
+
+```typescript
+// src/api/capture.ts:419 — for the Clio session, not this plan
+app.listen(config.port, '127.0.0.1', () => { /* ... */ });
+```
+
+**The firewall rule is the effective control and does not depend on that change.**
+With `3000/tcp` removed from ufw, the port is unreachable externally regardless of
+what Express binds, and nginx still reaches it over loopback. The loopback bind is
+defence in depth — it protects against a future ufw misconfiguration — so it is
+handed to the Clio session rather than blocking this task.
+
+```bash
+ssh root@144.202.88.7 '
+  ufw delete allow 3000/tcp
+  ufw status
+  ss -tlnp | grep 3000
+'
+```
+
+Expected: ufw no longer lists 3000. `ss` still shows `0.0.0.0:3000` — that is
+expected until the Clio change lands, and is why Step 10 verifies external
+unreachability directly rather than inferring it from the bind address.
+
+- [ ] **Step 10: Verify external unreachability directly**
+
+Because Express still binds `0.0.0.0`, this must be tested **from off-host** — a
+loopback test would succeed and prove nothing.
+
+```bash
+# From your laptop, NOT via ssh:
+curl -m 8 -s -o /dev/null -w "direct: %{http_code}\n" \
+  http://144.202.88.7:3000/capture || echo "direct: blocked (expected)"
+curl -s -o /dev/null -w "https:  %{http_code}\n" \
+  https://clio.lantzbuilds.com/health
+```
+
+Expected: the direct request times out or is refused (ufw drops it); HTTPS returns
+200. Run one more Shortcut capture to be certain, and exercise a CLI chat to
+confirm SSE still streams.
+
+- [ ] **Step 11: Commit**
+
+```bash
+git add scripts/vps/nginx-clio.conf
+git commit -m "feat: add Clio allowlist vhost with TLS and SSE support
+
+Publishes only paths with a known caller: POST /capture, the
+/capture/<id>/fix regex, GET /health, and /api/sessions/*. /status,
+/capture/bulk, /capture/fix, and /capture/fix/recent 404 at nginx even
+with a valid token, bounding a leaked credential. SSE settings prevent
+buffering of the CLI chat stream."
+```
+
+---
+
+## Task 7: fail2ban jails for nginx
+
+The host takes ~261 unsolicited requests a day — `zgrab/0.x`, a Dahua camera RCE probe, CGI enumeration — and fail2ban currently runs only the `sshd` jail.
+
+**Files:**
+- Create: `scripts/vps/fail2ban-nginx.local`, `scripts/vps/fail2ban-filter-clio-auth.conf`
+
+**Interfaces:**
+- Consumes: nginx access/error logs from Tasks 5–6.
+- Produces: active `nginx-http-auth`, `nginx-badbots`, and `clio-capture-auth` jails.
+
+- [ ] **Step 1: Write a custom filter for upstream 401s**
+
+The spec requires a jail on repeated `401`s against the capture route. The stock
+`nginx-http-auth` filter matches nginx's **own** `auth_basic` failures in
+`error.log` — it does **not** match a 401 returned by an upstream application. Clio
+returns its own 401s, so this needs a filter over `access.log`.
+
+`scripts/vps/fail2ban-filter-clio-auth.conf`:
+
+```ini
+# Match repeated 401s against Clio's capture routes in nginx's access log.
+# The stock nginx-http-auth filter only catches nginx's own auth_basic
+# failures in error.log, not 401s returned by an upstream app.
+#
+# Default combined log format:
+#   $remote_addr - $remote_user [$time_local] "$request" $status ...
+[Definition]
+failregex = ^<HOST> - \S+ \[[^\]]+\] "(?:GET|POST) /capture(?:/[^/"]+/fix)?(?:\?\S*)? HTTP/[\d.]+" 401
+ignoreregex =
+datepattern = \[%%d/%%b/%%Y:%%H:%%M:%%S %%z\]
+```
+
+- [ ] **Step 2: Write the jail config**
+
+`scripts/vps/fail2ban-nginx.local`:
+
+```ini
+# nginx jails for Clio and Formava. Installed to /etc/fail2ban/jail.d/.
+[nginx-http-auth]
+enabled  = true
+port     = http,https
+logpath  = /var/log/nginx/error.log
+maxretry = 5
+findtime = 600
+bantime  = 3600
+
+[nginx-badbots]
+enabled  = true
+port     = http,https
+logpath  = /var/log/nginx/access.log
+maxretry = 2
+findtime = 600
+bantime  = 86400
+
+# Brute-force protection for the capture bearer token. The legitimate client
+# is a human dictating, so repeated 401s are never normal traffic.
+[clio-capture-auth]
+enabled  = true
+port     = http,https
+filter   = clio-capture-auth
+logpath  = /var/log/nginx/access.log
+maxretry = 5
+findtime = 600
+bantime  = 86400
+```
+
+- [ ] **Step 3: Install and restart**
+
+```bash
+scp scripts/vps/fail2ban-filter-clio-auth.conf \
+    root@144.202.88.7:/etc/fail2ban/filter.d/clio-capture-auth.conf
+scp scripts/vps/fail2ban-nginx.local \
+    root@144.202.88.7:/etc/fail2ban/jail.d/nginx.local
+ssh root@144.202.88.7 'systemctl restart fail2ban && sleep 2 && fail2ban-client status'
+```
+
+- [ ] **Step 4: Verify the custom filter actually matches**
+
+A filter that compiles but matches nothing is worse than no filter, because it
+looks like protection. Test it against a real log line:
+
+```bash
+ssh root@144.202.88.7 '
+  printf "%s\n" \
+    "203.0.113.9 - - [31/Jul/2026:12:00:00 +0000] \"POST /capture HTTP/1.1\" 401 20 \"-\" \"curl/8.0\"" \
+    "203.0.113.9 - - [31/Jul/2026:12:00:01 +0000] \"POST /capture/abc123/fix HTTP/1.1\" 401 20 \"-\" \"curl/8.0\"" \
+    > /tmp/f2b-test.log
+  fail2ban-regex /tmp/f2b-test.log /etc/fail2ban/filter.d/clio-capture-auth.conf
+  rm /tmp/f2b-test.log
+'
+```
+
+Expected: `2 match(es)` for the failregex. If it reports 0, the log format differs
+— check `grep log_format /etc/nginx/nginx.conf` and adjust the regex.
+
+- [ ] **Step 5: Verify all four jails are active**
+
+```bash
+ssh root@144.202.88.7 '
+  fail2ban-client status
+  fail2ban-client status clio-capture-auth | head -8
+'
+```
+
+Expected: jail list contains `sshd`, `nginx-http-auth`, `nginx-badbots`, and
+`clio-capture-auth`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/vps/fail2ban-nginx.local scripts/vps/fail2ban-filter-clio-auth.conf
+git commit -m "feat: add nginx fail2ban jails incl. capture token brute-force
+
+The host takes ~261 unsolicited requests/day (zgrab, Dahua RCE probes,
+CGI enumeration) with only the sshd jail active. The capture-401 jail needs
+a custom access.log filter because stock nginx-http-auth only matches
+nginx's own auth_basic failures, not upstream 401s from Clio."
+```
+
+---
+
+## Task 8: 🛑 SSH hardening — key-only authentication
+
+**Gate B.** Verify key auth in a **second, separate SSH session** before disabling passwords. A mistake here locks you out and recovery needs Vultr's web console.
+
+**Files:** none (host configuration only).
+
+- [ ] **Step 1: Confirm a key is installed and works**
+
+In a **new terminal**, leaving your current session open:
+
+```bash
+ssh -i ~/.ssh/id_ed25519 -o PasswordAuthentication=no root@144.202.88.7 'echo KEY_AUTH_OK'
+```
+
+Expected: `KEY_AUTH_OK`. If this fails, install your public key first:
+
+```bash
+ssh-copy-id -i ~/.ssh/id_ed25519.pub root@144.202.88.7
+```
+
+Do not continue until the `PasswordAuthentication=no` probe succeeds.
+
+- [ ] **Step 2: Rotate the root password**
+
+Exposed in plaintext during assessment.
+
+```bash
+ssh root@144.202.88.7 'openssl rand -base64 24'
+# store it in your password manager, then:
+ssh root@144.202.88.7 'passwd root'
+```
+
+- [ ] **Step 3: Disable password authentication**
+
+```bash
+ssh root@144.202.88.7 '
+  sed -i "s/^#*PasswordAuthentication.*/PasswordAuthentication no/" /etc/ssh/sshd_config
+  sed -i "s/^#*PermitRootLogin.*/PermitRootLogin prohibit-password/" /etc/ssh/sshd_config
+  grep -E "^PasswordAuthentication|^PermitRootLogin" /etc/ssh/sshd_config
+  sshd -t && systemctl reload ssh
+'
+```
+
+`sshd -t` validates the config before reload — it refuses to apply a broken file.
+
+- [ ] **Step 4: Verify key auth still works and passwords are refused**
+
+**Keep your current session open** while testing in a new terminal:
+
+```bash
+ssh -i ~/.ssh/id_ed25519 root@144.202.88.7 'echo STILL_IN'
+ssh -o PubkeyAuthentication=no -o PreferredAuthentications=password \
+    root@144.202.88.7 'echo SHOULD_NOT_PRINT' || echo "password auth refused (expected)"
+```
+
+Expected: `STILL_IN`, then `Permission denied` for the password attempt.
+
+- [ ] **Step 5: Note the deploy-script implication**
+
+Clio's `scripts/deploy.sh` prefers `VPS_PASSWORD` over `VPS_KEY_PATH` when both are set (`../clio-ai-assitant/scripts/deploy.sh:42-51`), so it will break after this change. Remove or comment `VPS_PASSWORD` in `../clio-ai-assitant/.env` so the script takes the key-auth branch. `scripts/deploy_vps.sh` already uses keys only.
+
+- [ ] **Step 6: Verify ufw is at its final state**
+
+```bash
+ssh root@144.202.88.7 'ufw status verbose'
+```
+
+Expected: allow rules for `22`, `80`, `443` only. No `3000/tcp`.
+
+---
+
+## Task 9: Nightly pg_dump backups
+
+**Files:**
+- Create: `scripts/vps/pg_backup.sh`, `scripts/vps/formava-backup.service`, `scripts/vps/formava-backup.timer`
+
+**Interfaces:**
+- Consumes: the `formava` database (Task 3).
+- Produces: nightly gzipped dumps in `/var/backups/formava`, 7-day retention, via `formava-backup.timer`.
+
+- [ ] **Step 1: Write the backup script**
+
+`scripts/vps/pg_backup.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Nightly pg_dump of the formava database with 7-day retention.
+set -euo pipefail
+
+BACKUP_DIR="/var/backups/formava"
+DB_NAME="formava"
+RETENTION_DAYS=7
+STAMP="$(date +%Y%m%d-%H%M%S)"
+TARGET="${BACKUP_DIR}/${DB_NAME}-${STAMP}.sql.gz"
+
+mkdir -p "${BACKUP_DIR}"
+chmod 0700 "${BACKUP_DIR}"
+
+sudo -u postgres pg_dump --no-owner "${DB_NAME}" | gzip > "${TARGET}"
+
+# Fail loudly on an empty or tiny dump rather than silently keeping garbage.
+if [ ! -s "${TARGET}" ] || [ "$(stat -c%s "${TARGET}")" -lt 100 ]; then
+    echo "ERROR: backup ${TARGET} is empty or truncated" >&2
+    exit 1
+fi
+
+find "${BACKUP_DIR}" -name "${DB_NAME}-*.sql.gz" \
+    -mtime "+${RETENTION_DAYS}" -delete
+
+echo "Backup complete: ${TARGET} ($(du -h "${TARGET}" | cut -f1))"
+```
+
+- [ ] **Step 2: Write the unit and timer**
+
+`scripts/vps/formava-backup.service`:
+
+```ini
+[Unit]
+Description=Formava Postgres backup
+After=postgresql.service
+Requires=postgresql.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/formava/scripts/vps/pg_backup.sh
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=formava-backup
+```
+
+`scripts/vps/formava-backup.timer`:
+
+```ini
+[Unit]
+Description=Nightly Formava Postgres backup
+
+[Timer]
+OnCalendar=daily
+# Spread load off the hour, and survive missed windows after a reboot.
+RandomizedDelaySec=1800
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+- [ ] **Step 3: Install and enable**
+
+```bash
+chmod +x scripts/vps/pg_backup.sh
+./scripts/deploy_vps.sh sync
+ssh root@144.202.88.7 '
+  chmod +x /opt/formava/scripts/vps/pg_backup.sh
+  cp /opt/formava/scripts/vps/formava-backup.service /etc/systemd/system/
+  cp /opt/formava/scripts/vps/formava-backup.timer   /etc/systemd/system/
+  systemctl daemon-reload
+  systemctl enable --now formava-backup.timer
+'
+```
+
+- [ ] **Step 4: Run it once and verify the artifact**
+
+```bash
+ssh root@144.202.88.7 '
+  systemctl start formava-backup.service
+  journalctl -u formava-backup --no-pager -n 10
+  ls -la /var/backups/formava/
+  systemctl list-timers formava-backup --no-pager
+'
+```
+
+Expected: journal reports "Backup complete"; a non-empty `.sql.gz` exists; the timer shows a next-run time.
+
+- [ ] **Step 5: Verify the dump actually restores**
+
+An untested backup is not a backup.
+
+```bash
+ssh root@144.202.88.7 '
+  LATEST=$(ls -t /var/backups/formava/*.sql.gz | head -1)
+  sudo -u postgres createdb formava_restore_test
+  gunzip -c "${LATEST}" | sudo -u postgres psql -q formava_restore_test
+  sudo -u postgres psql -d formava_restore_test -tAc \
+    "SELECT extversion FROM pg_extension WHERE extname=\"vector\""
+  sudo -u postgres dropdb formava_restore_test
+  echo "restore verified"
+'
+```
+
+Expected: the pgvector version prints, then `restore verified`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add scripts/vps/pg_backup.sh scripts/vps/formava-backup.service \
+        scripts/vps/formava-backup.timer
+git commit -m "feat: add nightly pg_dump backups with restore verification
+
+Fails loudly on an empty or truncated dump rather than retaining garbage.
+Persistent=true so a missed window runs after reboot."
+```
+
+---
+
+## Task 10: Verification script and CI deploy wiring
+
+**Files:**
+- Create: `scripts/vps/verify.sh`
+- Modify: `.github/workflows/ci.yml` (replace both `echo` deploy stubs)
+
+**Interfaces:**
+- Consumes: every prior task.
+- Produces: `scripts/vps/verify.sh`, a re-runnable assertion of every spec §6 exit criterion, exiting non-zero on any failure.
+
+- [ ] **Step 1: Write the verification script**
+
+`scripts/vps/verify.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Assert every Spec 1 exit criterion. Safe to re-run. Exits non-zero on failure.
+#
+# Usage: CLIO_TOKEN=<token> ./scripts/vps/verify.sh
+set -uo pipefail
+
+VPS="${VPS_HOST:-144.202.88.7}"
+SSH="ssh root@${VPS}"
+FAIL=0
+
+pass() { echo "  ok    $1"; }
+fail() { echo "  FAIL  $1"; FAIL=1; }
+
+check() { # description, actual, expected
+    [ "$2" = "$3" ] && pass "$1 ($2)" || fail "$1 — got '$2', want '$3'"
+}
+
+echo "== Formava =="
+check "http->https redirect" \
+  "$(curl -s -o /dev/null -w '%{http_code}' http://formava.io)" "301"
+check "https serves app" \
+  "$(curl -s -o /dev/null -w '%{http_code}' https://formava.io)" "200"
+
+HEALTH="$(curl -s https://formava.io/api/health)"
+echo "$HEALTH" | grep -q '"db":"ok"' \
+  && pass "BFF health chain ($HEALTH)" || fail "BFF health chain — got '$HEALTH'"
+
+echo "== Clio allowlist =="
+if [ -n "${CLIO_TOKEN:-}" ]; then
+    for p in /status /capture/bulk /capture/fix /capture/fix/recent /v404/exec; do
+        check "closed: $p" \
+          "$(curl -s -o /dev/null -w '%{http_code}' \
+             -H "Authorization: Bearer ${CLIO_TOKEN}" \
+             "https://clio.lantzbuilds.com${p}")" "404"
+    done
+    check "GET /capture rejected" \
+      "$(curl -s -o /dev/null -w '%{http_code}' \
+         -H "Authorization: Bearer ${CLIO_TOKEN}" \
+         https://clio.lantzbuilds.com/capture)" "403"
+else
+    echo "  skip  allowlist checks (set CLIO_TOKEN)"
+fi
+check "clio /health reachable" \
+  "$(curl -s -o /dev/null -w '%{http_code}' https://clio.lantzbuilds.com/health)" "200"
+check "capture 401 without token" \
+  "$(curl -s -o /dev/null -w '%{http_code}' -X POST \
+     -H 'Content-Type: application/json' -d '{"text":"x"}' \
+     https://clio.lantzbuilds.com/capture)" "401"
+
+# Tested from off-host on purpose: Clio still binds 0.0.0.0 (see Task 6 Step 9),
+# so ufw is what makes port 3000 unreachable. A loopback test would pass and
+# prove nothing.
+timeout 8 curl -s -o /dev/null "http://${VPS}:3000/capture" 2>/dev/null \
+  && fail "port 3000 externally blocked" \
+  || pass "port 3000 externally blocked"
+
+echo "== Host =="
+check "services active" \
+  "$($SSH 'systemctl is-active postgresql formava-api formava-web clio nginx | sort -u | tr -d "\n"')" \
+  "active"
+check "ufw ports" \
+  "$($SSH "ufw status | grep -cE '^(22|80|443)'")" "3"
+check "no 3000 in ufw" "$($SSH 'ufw status | grep -c 3000')" "0"
+# 3000 deliberately excluded: Clio binds 0.0.0.0 until the Clio session applies
+# the one-line listen() change. Firewall coverage is asserted above instead.
+check "formava binds loopback only" \
+  "$($SSH "ss -tln | grep -cE '0\.0\.0\.0:(3001|8000|5432)'")" "0"
+check "api MemoryMax" \
+  "$($SSH 'systemctl show formava-api -p MemoryMax --value')" "805306368"
+check "web MemoryMax" \
+  "$($SSH 'systemctl show formava-web -p MemoryMax --value')" "536870912"
+check "gradio absent" "$($SSH 'test -e /opt/formava/app/pages; echo $?')" "1"
+check "password auth off" \
+  "$($SSH "grep -c '^PasswordAuthentication no' /etc/ssh/sshd_config")" "1"
+for jail in nginx-badbots nginx-http-auth clio-capture-auth; do
+    check "fail2ban jail ${jail}" \
+      "$($SSH "fail2ban-client status ${jail} >/dev/null 2>&1; echo \$?")" "0"
+done
+check "backup timer" \
+  "$($SSH 'systemctl is-active formava-backup.timer')" "active"
+$SSH 'ls /var/backups/formava/*.sql.gz >/dev/null 2>&1' \
+  && pass "backup artifact present" || fail "backup artifact present"
+$SSH 'certbot renew --dry-run' >/dev/null 2>&1 \
+  && pass "cert renewal dry-run" || fail "cert renewal dry-run"
+
+echo
+echo "== Memory =="
+$SSH 'free -h | head -2'
+
+[ "$FAIL" -eq 0 ] && echo "ALL CHECKS PASSED" || echo "SOME CHECKS FAILED"
+exit "$FAIL"
+```
+
+- [ ] **Step 2: Run it**
+
+```bash
+chmod +x scripts/vps/verify.sh
+CLIO_TOKEN=<new-token> ./scripts/vps/verify.sh
+```
+
+Expected: `ALL CHECKS PASSED`, exit 0. Fix any failures before continuing.
+
+- [ ] **Step 3: Replace the CI deploy stubs**
+
+In `.github/workflows/ci.yml`, replace the `deploy-staging` and `deploy-production` jobs — both currently just `echo "This would trigger Render deployment"` — with a single VPS deploy job. Staging is dropped per the spec, so `main` deploys to the VPS while Render remains live and untouched as fallback.
+
+```yaml
+  # Deploy to the VPS (main branch). Render remains live as fallback
+  # until Spec 4; this workflow does not touch it.
+  deploy-vps:
+    needs: [test-backend, test-frontend]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '20'
+        cache: 'npm'
+        cache-dependency-path: frontend/package-lock.json
+
+    - name: Build frontend
+      working-directory: ./frontend
+      run: npm ci && npm run build
+
+    - name: Configure SSH
+      run: |
+        mkdir -p ~/.ssh
+        echo "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/id_ed25519
+        chmod 600 ~/.ssh/id_ed25519
+        ssh-keyscan -H ${{ secrets.VPS_HOST }} >> ~/.ssh/known_hosts
+
+    - name: Deploy
+      env:
+        VPS_HOST: ${{ secrets.VPS_HOST }}
+      run: |
+        ./scripts/deploy_vps.sh sync
+        ./scripts/deploy_vps.sh install
+        ./scripts/deploy_vps.sh restart
+
+    - name: Verify
+      run: |
+        curl -sf https://formava.io/api/health | grep '"db":"ok"'
+```
+
+Also bump `node-version: '18'` to `'20'` in the existing `test-frontend` job, and drop `feature/nextjs-migration` from the `on.push.branches` list if that branch is no longer in use.
+
+Add two repository secrets: `VPS_SSH_KEY` (a deploy private key, not your personal one) and `VPS_HOST`.
+
+- [ ] **Step 4: Verify CI passes**
+
+```bash
+git add .github/workflows/ci.yml scripts/vps/verify.sh
+git commit -m "feat: add verification script and wire CI to deploy to the VPS
+
+Replaces both echo-stub deploy jobs with a real VPS deploy. verify.sh
+asserts every Spec 1 exit criterion and is safe to re-run. Render is
+untouched and remains the fallback until Spec 4."
+git push -u origin spec/vps-infra-migration
+```
+
+Then confirm the Actions run is green (the deploy job is skipped on a non-`main` branch, which is expected).
+
+- [ ] **Step 5: Final full verification**
+
+```bash
+CLIO_TOKEN=<new-token> ./scripts/vps/verify.sh
+```
+
+Expected: `ALL CHECKS PASSED`.
+
+---
+
+## Definition of Done
+
+- [ ] `https://formava.io/api/health` returns `{"db":"ok","pgvector":"..."}` over TLS
+- [ ] `scripts/vps/verify.sh` exits 0 with all checks passing
+- [ ] iOS Shortcuts (capture and fix) work over HTTPS on a rotated token
+- [ ] Clio CLI works over HTTPS, and chat **streams incrementally** (SSE unbuffered)
+- [ ] Telegram bot still responds (long polling, unaffected)
+- [ ] `ufw status` shows 22, 80, 443 only
+- [ ] Port 3000 unreachable **from off-host** (ufw; Clio still binds `0.0.0.0` pending its one-line `listen()` change)
+- [ ] Formava processes bind loopback only on 3001, 8000, 5432
+- [ ] Password SSH refused; key auth works
+- [ ] A `pg_dump` artifact exists and has been proven to restore
+- [ ] No Gradio file exists under `/opt/formava`
+- [ ] Total host memory use ≤ 1.5 GB
+- [ ] Render still live and untouched
+
+## Deferred to Later Specs
+
+| Item | Spec |
+|------|------|
+| Tables, SQLAlchemy models, Alembic baseline, re-embed into pgvector | 2 |
+| Delete `views.py`, `couchdb`, `chromadb`, `langchain` | 2 |
+| LLM provider seam; split `openai_service.py`; fix `tiktoken` | 3 |
+| Real REST API, cookie auth, `apiClient` auth methods, delete Gradio | 4 |
+| Retire Render | after 4 |
+| Clio token splitting, fail-fast config, source-IP logging, `/status` | `../clio-ai-assitant/docs/INFRA-HANDOFF.md` |

--- a/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
+++ b/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
@@ -2074,7 +2074,17 @@ Persistent=true so a missed window runs after reboot."
 - Consumes: every prior task.
 - Produces: `scripts/vps/verify.sh`, a re-runnable assertion of every spec §6 exit criterion, exiting non-zero on any failure.
 
-- [ ] **Step 1: Write the verification script**
+- [x] **Step 1: Write the verification script**
+
+> **The draft below is superseded. `scripts/vps/verify.sh` as shipped is the
+> authority.** It diverges in eight places — the five stale items in
+> `HANDOFF.md`, plus three the live host contradicted (ufw prints a v4 *and* a
+> v6 rule per port so "expect 3" reads 6; `PasswordAuthentication` lives in an
+> `sshd_config.d` drop-in so grepping `sshd_config` is a false negative;
+> fail2ban jails must be checked by logpath, not status). It also guards
+> against two self-inflicted failures the draft could not have anticipated:
+> the script's own 401 probes trip the `clio-capture-auth` jail (24h ban), and
+> its `/capture` probes spend that location's entire nginx rate-limit burst.
 
 `scripts/vps/verify.sh`:
 
@@ -2172,16 +2182,18 @@ $SSH 'free -h | head -2'
 exit "$FAIL"
 ```
 
-- [ ] **Step 2: Run it**
+- [x] **Step 2: Run it**
 
 ```bash
 chmod +x scripts/vps/verify.sh
-CLIO_TOKEN=<new-token> ./scripts/vps/verify.sh
+./scripts/vps/verify.sh    # no token argument; it reads both off the host
 ```
 
 Expected: `ALL CHECKS PASSED`, exit 0. Fix any failures before continuing.
 
-- [ ] **Step 3: Replace the CI deploy stubs**
+Result: 40/40, exit 0, run twice back to back to prove re-runnability.
+
+- [x] **Step 3: Replace the CI deploy stubs**
 
 In `.github/workflows/ci.yml`, replace the `deploy-staging` and `deploy-production` jobs — both currently just `echo "This would trigger Render deployment"` — with a single VPS deploy job. Staging is dropped per the spec, so `main` deploys to the VPS while Render remains live and untouched as fallback.
 
@@ -2244,6 +2256,18 @@ git push -u origin spec/vps-infra-migration
 ```
 
 Then confirm the Actions run is green (the deploy job is skipped on a non-`main` branch, which is expected).
+
+> **Correction:** pushing the branch triggers nothing. The workflow fires only
+> on pushes to `main`/`production` and on PRs targeting them, so a push to
+> `spec/vps-infra-migration` produces no run at all. A PR to `main` is what
+> gets the signal: `test-backend` and `test-frontend` run, while `docker-build`
+> (push-only) and `deploy-vps` (main-only) both skip. Opened as PR #91.
+>
+> The step also required an unplanned fix. `Test imports` ran `import
+> app.main`, which pulls in the Gradio layer and hard-requires CouchDB — a
+> service neither CI nor the VPS runs. It could never have gone green.
+> Repointed at `app.health.api:create_app`, the entrypoint `formava-api`
+> actually executes, scoped for the same reason as the ruff step.
 
 - [ ] **Step 5: Final full verification**
 

--- a/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
+++ b/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
@@ -121,7 +121,7 @@ Pure local work. No VPS access needed. Establishes the ≥80% coverage standard 
 - Produces:
   - `app.health.checks.PostgresHealth` — Pydantic model, fields `db: str`, `pgvector: str`
   - `app.health.checks.check_postgres(dsn: str) -> PostgresHealth` — raises `psycopg.Error` on failure, never returns a degraded value
-  - `app.health.api.create_app() -> FastAPI` and module-level `app` — uvicorn target is `app.health.api:app`
+  - `app.health.api.create_app(dsn: str | None = None) -> FastAPI` — **no module-level `app`**; uvicorn target is `app.health.api:create_app --factory`
   - `/health` → `200 {"db": "ok", "pgvector": "<version>"}` or `503 {"detail": "..."}`
 
 - [ ] **Step 1: Add the dependency files**
@@ -388,10 +388,12 @@ def create_app(dsn: str | None = None) -> FastAPI:
         return result.model_dump()
 
     return application
-
-
-app = create_app()
 ```
+
+**No module-level `app`.** uvicorn calls the factory itself via `--factory`, so
+importing this module has no side effects and needs no environment variable. That
+keeps `pytest tests/unit/` runnable with zero configuration while preserving
+fail-fast behaviour at real startup.
 
 - [ ] **Step 10: Run the full suite and the linters**
 
@@ -582,13 +584,29 @@ export interface HealthPayload {
  *
  * Server-side only. The browser never calls FastAPI directly under the BFF
  * pattern -- it calls Next.js route handlers, which call FastAPI.
+ *
+ * Deliberately has no default: the "No silent fallbacks" global constraint
+ * applies to configuration as well as to data access. systemd supplies this
+ * via EnvironmentFile; local development sets it explicitly.
+ *
+ * Resolved lazily rather than at module load. `next build` imports this module
+ * for static analysis, and CI builds without runtime configuration -- a
+ * top-level throw would break the build rather than the request. Throwing on
+ * first use still fails loudly: the route handler turns it into a 503, which
+ * the constraint permits.
  */
-const API_BASE_URL = process.env.FORMAVA_API_URL ?? 'http://127.0.0.1:8000';
+function getApiBaseUrl(): string {
+  const url = process.env.FORMAVA_API_URL;
+  if (!url) {
+    throw new Error('FORMAVA_API_URL is not set; refusing to serve');
+  }
+  return url;
+}
 
 class ApiClient {
   async health(): Promise<ApiResponse<HealthPayload>> {
     try {
-      const res = await fetch(`${API_BASE_URL}/health`, {
+      const res = await fetch(`${getApiBaseUrl()}/health`, {
         cache: 'no-store',
       });
 
@@ -714,6 +732,16 @@ Expected: `{"db":"ok","pgvector":"0.6.0"}` (version may differ)
 
 Now stop uvicorn and re-run the curl.
 Expected: HTTP 503 with an `error` field — confirming failures propagate rather than being swallowed.
+
+Finally, confirm missing configuration also surfaces as a 503 rather than a
+silent default. Restart `npm run dev` **without** `FORMAVA_API_URL`:
+
+```bash
+cd frontend && npm run dev
+curl -s -o /dev/null -w "%{http_code}\n" http://localhost:3000/api/health
+```
+
+Expected: `503`. A `200` would mean a default crept back in.
 
 - [ ] **Step 10: Commit**
 
@@ -886,7 +914,7 @@ Type=simple
 User=root
 WorkingDirectory=/opt/formava
 EnvironmentFile=/etc/formava/formava.env
-ExecStart=/opt/formava/.venv/bin/uvicorn app.health.api:app \
+ExecStart=/opt/formava/.venv/bin/uvicorn app.health.api:create_app --factory \
     --host 127.0.0.1 --port 8000
 Restart=on-failure
 RestartSec=5

--- a/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
+++ b/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
@@ -2243,7 +2243,7 @@ Also bump `node-version: '18'` to `'20'` in the existing `test-frontend` job, an
 
 Add two repository secrets: `VPS_SSH_KEY` (a deploy private key, not your personal one) and `VPS_HOST`.
 
-- [ ] **Step 4: Verify CI passes**
+- [x] **Step 4: Verify CI passes**
 
 ```bash
 git add .github/workflows/ci.yml scripts/vps/verify.sh
@@ -2269,13 +2269,18 @@ Then confirm the Actions run is green (the deploy job is skipped on a non-`main`
 > Repointed at `app.health.api:create_app`, the entrypoint `formava-api`
 > actually executes, scoped for the same reason as the ruff step.
 
-- [ ] **Step 5: Final full verification**
+- [x] **Step 5: Final full verification**
 
 ```bash
-CLIO_TOKEN=<new-token> ./scripts/vps/verify.sh
+./scripts/vps/verify.sh
 ```
 
 Expected: `ALL CHECKS PASSED`.
+
+Result: passed, exit 0, on three consecutive runs. `clio-capture-auth` left with
+its original `ignoreip` list and nobody banned. The third run took ~5 min rather
+than ~1: the `/capture` bucket was depleted by the two prior runs and the
+backoff waited it out, which is the intended behaviour.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
+++ b/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
@@ -721,7 +721,7 @@ With Postgres from Task 1 up, in two terminals:
 ```bash
 # terminal 1
 export FORMAVA_DATABASE_URL="postgresql://formava:formava_dev@localhost:5432/formava"
-python -m uvicorn app.health.api:app --host 127.0.0.1 --port 8000
+python -m uvicorn app.health.api:create_app --factory --host 127.0.0.1 --port 8000
 
 # terminal 2
 cd frontend && FORMAVA_API_URL=http://127.0.0.1:8000 npm run dev
@@ -894,7 +894,7 @@ replace rather than accumulate."
 - Create: `scripts/vps/formava-api.service`, `scripts/vps/formava-web.service`, `scripts/deploy_vps.sh`
 
 **Interfaces:**
-- Consumes: `app.health.api:app` (Task 1); `frontend/.next/standalone/server.js` (Task 2); Postgres DSN (Task 3).
+- Consumes: `app.health.api:create_app` via `--factory` (Task 1); `frontend/.next/standalone/server.js` (Task 2); Postgres DSN (Task 3).
 - Produces: `formava-api.service` on `127.0.0.1:8000`, `formava-web.service` on `127.0.0.1:3001`, both reading `/etc/formava/formava.env`. `scripts/deploy_vps.sh` with subcommands `deploy|sync|install|build|restart|logs|status`.
 
 - [ ] **Step 1: Write the API unit**

--- a/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
+++ b/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
@@ -31,6 +31,22 @@
 - CI runs `ruff check app/` and `ruff format --check app/` with no config file, so ruff defaults apply (line length 88). All new `app/` code must pass both.
 - VPS: `144.202.88.7`, user `root`. SSH via `scripts/deploy.sh`-style `sshpass`/key auth already configured in `../clio-ai-assitant/.env`.
 
+## Cross-Repo Sequencing (Clio)
+
+Clio-side findings live in `../clio-ai-assitant/docs/INFRA-HANDOFF.md` and are
+owned by a separate session. Only one is order-sensitive:
+
+| Clio finding | Run | Reason |
+|---|---|---|
+| **2 — fail-fast config** | **Before Task 6** | Task 6 Step 7 edits `/opt/clio/.env`. Clio's `\|\| 'dev-token'` fallback (`src/index.ts:59`) turns a botched edit into a silent boot on a repository-published token. Landing this first converts that into a refusal to start. |
+| 3 — loopback bind | After Task 6 Step 9 | One line. The ufw rule is already the effective control; this is defence in depth and lets `verify.sh` drop its off-host workaround. |
+| 4 — source-IP logging | After Spec 1 | nginx supplies source IPs at the proxy layer from Task 5 onward. |
+| 1 — token splitting | After Spec 1 | Costs one extra manual phone edit. Not worth interleaving a code change into a cutover; TLS (Task 6) is the acute fix and shouldn't wait on it. |
+| 5, 6 | Anytime | No coupling. |
+
+If finding 2 has **not** landed before Task 6, Step 7's assertions are the
+compensating control — do not skip them.
+
 ## Manual Steps (Human, Not Agent)
 
 Three things an agent cannot do. The plan halts at each until confirmed:
@@ -1353,17 +1369,51 @@ Expected: nginx access log shows `POST /capture` (and the fix route) with **your
 
 The current token was exposed in plaintext during assessment.
 
+⚠️ **This step is the one place where Clio's `|| 'dev-token'` fallback is
+dangerous** (`src/index.ts:59`, handoff finding 2). If the `sed` below mangles or
+removes the line, `process.env.CAPTURE_API_TOKEN` becomes undefined and Clio boots
+on a token that is published in its own repository — while `systemctl is-active`
+still reports `active`. The assertions are not optional.
+
 ```bash
 ssh root@144.202.88.7 '
+  set -e
   NEW="$(openssl rand -hex 32)"
-  echo "NEW TOKEN: ${NEW}"
-  sed -i "s/^CAPTURE_API_TOKEN=.*/CAPTURE_API_TOKEN=${NEW}/" /opt/clio/.env
+
+  # Assert the variable exists in the expected form before editing it.
+  grep -qE "^CAPTURE_API_TOKEN=" /opt/clio/.env \
+    || { echo "ABORT: CAPTURE_API_TOKEN= line not found as expected"; exit 1; }
+
+  cp /opt/clio/.env /opt/clio/.env.bak
+  sed -i "s|^CAPTURE_API_TOKEN=.*|CAPTURE_API_TOKEN=${NEW}|" /opt/clio/.env
+
+  # Assert the edit actually took.
+  grep -qF "CAPTURE_API_TOKEN=${NEW}" /opt/clio/.env \
+    || { echo "ABORT: rotation did not apply; restoring"; \
+         mv /opt/clio/.env.bak /opt/clio/.env; exit 1; }
+
   systemctl restart clio
-  sleep 3 && systemctl is-active clio
+  sleep 3
+  systemctl is-active clio
+  echo "NEW TOKEN: ${NEW}"
 '
 ```
 
-Then on the phone, update the `Authorization: Bearer <token>` header in **both** Shortcuts, and run `clio config set-token <new>` for the CLI.
+Then assert Clio is **not** running on the fallback token:
+
+```bash
+curl -s -o /dev/null -w "dev-token: %{http_code}\n" -X POST \
+  -H "Authorization: Bearer dev-token" -H 'Content-Type: application/json' \
+  -d '{"text":"fallback probe"}' https://clio.lantzbuilds.com/capture
+```
+
+Expected: **401**. A 200 or 201 means the rotation silently failed into the
+hardcoded fallback — restore `/opt/clio/.env.bak`, restart Clio, and fix
+handoff finding 2 before retrying.
+
+Then on the phone, update the `Authorization: Bearer <token>` header in **both**
+Shortcuts, and run `clio config set-token <new>` for the CLI. Once Step 8 passes,
+remove the backup: `rm /opt/clio/.env.bak`.
 
 - [ ] **Step 8: Verify captures and CLI still work on the new token**
 

--- a/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
+++ b/docs/superpowers/plans/2026-07-31-vps-infra-datastore.md
@@ -1540,6 +1540,65 @@ ssh root@144.202.88.7 '
 
 Expected: nginx access log shows `POST /capture` (and the fix route) with **your phone's source IP** — the observability gap is now closed — and Clio's log shows the capture arriving. Confirm the dictated text landed in the inbox.
 
+- [ ] **Step 7 PRECONDITION 🔴 — the split must be DEPLOYED, not merely committed**
+
+The runbook directs Step 7 to install `CAPTURE_TOKEN` and `SESSION_TOKEN`. That
+only works if the **running build** reads them. Verified on the host
+2026-08-01:
+
+```
+grep -c "CAPTURE_TOKEN\|SESSION_TOKEN" /opt/clio/dist/src/utils/config.js   → 0
+/opt/clio/dist/src/api/capture.js still contains /capture/bulk, /capture/fix,
+                                                 /capture/fix/recent
+/opt/clio/.env token vars: CAPTURE_API_TOKEN, TELEGRAM_BOT_TOKEN  (no new ones)
+
+deployed build mtime  2026-07-31 21:14:13 UTC  (= 14:14 -0700)
+f4e770a  split          committed 17:36 -0700  → 3h22m AFTER the deploy
+9972b58  route deletion committed 19:42 -0700  → 5h28m AFTER the deploy
+```
+
+The deploy carried finding 2 (fail-fast, `4bc5f41`) but **not** finding 1.
+
+**Why this is not merely untidy.** Run Step 7 against the current build and:
+
+1. The new variables are written and Clio restarts fine — the old build ignores
+   them, still honouring `CAPTURE_API_TOKEN`, so nothing looks wrong.
+2. The Shortcut is then given `CAPTURE_TOKEN`, which the running server has never
+   heard of → **capture breaks**, and only a dictated capture reveals it.
+3. Worse, the runbook's own scope assertion —
+   `capture-token on /api/sessions → expect 401` — **passes for the wrong
+   reason.** A 401 from "unknown token" is indistinguishable from a 401 from
+   "valid token, wrong scope." The check designed to prove the split works would
+   confirm it while it is absent.
+
+**Gate:** before Step 7, confirm the split is live:
+
+```bash
+ssh root@144.202.88.7 'grep -c "CAPTURE_TOKEN" /opt/clio/dist/src/utils/config.js'
+```
+
+Must be non-zero. If it is `0`, stop — CLIO must deploy `f4e770a` + `9972b58`
+first.
+
+**Add a positive control to Step 8**, so the scope assertion cannot pass for the
+wrong reason. Assert the capture token is *recognised* before asserting it is
+*scoped*:
+
+```bash
+# Positive control: the capture token must WORK on its own route.
+curl -s -o /dev/null -w "capture-token on /capture:      %{http_code}\n" -X POST \
+  -H "Authorization: Bearer ${CAP}" -H 'Content-Type: application/json' \
+  -d '{"text":"scope check"}' https://clio.lantzbuilds.com/capture
+
+# Scope assertion: the same token must NOT open the agent surface.
+curl -s -o /dev/null -w "capture-token on /api/sessions: %{http_code}\n" -X POST \
+  -H "Authorization: Bearer ${CAP}" -H 'Content-Type: application/json' \
+  -d '{}' https://clio.lantzbuilds.com/api/sessions
+```
+
+Expected: **200/201 then 401**. A 401 on *both* means the token is simply
+unrecognised and the split is not in effect.
+
 - [ ] **Step 7: 🛑 HUMAN — rotate the token, then update the Shortcuts again**
 
 The current token was exposed in plaintext during assessment.

--- a/docs/superpowers/plans/HANDOFF.md
+++ b/docs/superpowers/plans/HANDOFF.md
@@ -1,0 +1,110 @@
+# Handoff — Spec 1 VPS migration, Task 10 remaining
+
+**Written:** 2026-08-16, at the end of a long session. Read this before Task 10.
+
+## Read these, in order
+
+1. **This file** — what changed since the plan was written.
+2. `docs/superpowers/plans/2026-07-31-vps-infra-datastore.md` — Task 10's steps.
+   Authoritative for *commands*, but see "Stale" below.
+3. `.superpowers/sdd/2026-07-31-vps-infra-datastore/progress.md` — the ledger,
+   full decision history and deferred minors.
+
+The plan's Task 10 is the only work left. Tasks 1–9 are complete and reviewed.
+
+## State: everything is live and working
+
+```
+https://formava.io/api/health        {"db":"ok","pgvector":"0.6.0"}
+https://www.formava.io/              301 → apex
+https://clio.lantzbuilds.com/health  200
+port 3000                            closed at ufw, unreachable off-host
+ssh                                  key-only, passwords refused
+fail2ban                             4 jails, all reading real log files
+backups                              nightly timer, restore + size guard proven
+```
+
+Six services active: `clio`, `clio-cron`, `nginx`, `postgresql`, `formava-api`,
+`formava-web`. Local suite: 10 passing in 0.76s.
+
+## 🔴 Stale in the plan — fix these before running Task 10
+
+**1. `verify.sh` uses `CLIO_TOKEN`. That variable no longer exists.**
+
+The legacy `CAPTURE_API_TOKEN` was deleted in Task 6 Step 7c. Clio now has two
+scoped tokens in `/opt/clio/.env`: `CAPTURE_TOKEN` and `SESSION_TOKEN`.
+
+Replace `CLIO_TOKEN` with `CAPTURE_TOKEN`, read on the host rather than passed
+in, so no secret enters shell history:
+
+```bash
+CAP=$(ssh root@144.202.88.7 "grep '^CAPTURE_TOKEN=' /opt/clio/.env | cut -d= -f2-")
+```
+
+**2. `/api/sessions` is PUBLISHED. It must not 404.**
+
+The plan's earlier draft had it closed. The Clio CLI uses it. Correct assertions:
+
+| Path | With `CAPTURE_TOKEN` | Reason |
+|---|---|---|
+| `POST /capture` | not 401 | capture scope |
+| `POST /api/sessions` | **401** | scope isolation — the whole point of the split |
+| `POST /capture/<id>/fix` | not 401 | published regex route |
+| `GET /capture` | 403 | `limit_except POST` |
+| `/status`, `/capture/bulk`, `/capture/fix`, `/capture/fix/recent`, `/v404/exec` | 404 | closed at nginx |
+
+`SESSION_TOKEN` is the mirror: 200 on `/api/sessions`, 401 on `/capture`.
+
+**3. Password SSH is gone. Anything using `sshpass` fails.**
+
+Use `ssh -i ~/.ssh/id_ed25519`. `scripts/deploy_vps.sh:19` already uses plain
+`ssh`, so it is fine. The CI deploy job in Task 10 Step 3 needs a `VPS_SSH_KEY`
+repo secret, as the plan says.
+
+**4. `ss` still shows `*:3000`. That is expected, not a bug.**
+
+Clio binds all interfaces; `ufw` is what closes the port. Test reachability
+**from off-host** — a loopback test passes while the port is wide open. Clio
+finding 3 (a one-line `app.listen` change) would fix the bind, and is still open
+on the Clio side.
+
+**5. Add a `clio-cron` check.** Two Clio units exist, not one.
+
+## Gotchas that cost real time this session
+
+**fail2ban jails can be "active" and blind.** `defaults-debian.conf` sets
+`backend = systemd`, which silently overrides `logpath`. Always verify with
+`fail2ban-client get <jail> logpath` — it must name a file. Already fixed for the
+three nginx jails via `backend = auto`; do not change the global default, the
+`sshd` jail legitimately uses systemd and works.
+
+**Never test bans with a routable IP.** Use `203.0.113.7` (RFC 5737). Real IPs in
+play: `76.121.153.187` is the human's phone, `144.202.88.7` is the server.
+
+**CI lint is scoped to `app/health/` on purpose.** The Gradio layer carries 107
+pre-existing ruff violations and is deleted in Spec 4. Widen the path as later
+specs land; do not "fix" it by unscoping.
+
+**Verify the property, not the directive.** `sshd -T` reported
+`permitrootlogin yes` while root was already key-only. What mattered was that a
+password login was refused.
+
+## Task 10, condensed
+
+1. Write `scripts/vps/verify.sh` with the corrections above.
+2. Run it; every check passes.
+3. Replace the two `echo` deploy stubs in `.github/workflows/ci.yml` with the
+   real VPS deploy job (plan Step 3). Add `VPS_SSH_KEY` and `VPS_HOST` secrets.
+   Bump `test-frontend` to Node 20.
+4. Push the branch, confirm Actions is green.
+
+Then the whole-branch review, then `superpowers:finishing-a-development-branch`.
+
+## Open, not blocking
+
+- **Clio model ID `claude-sonnet-4-20250514` returns 404.** Every capture
+  analysis silently falls back. Clio-side fix.
+- Clio vault git sync failing: `Cannot rebase onto multiple branches`.
+- Clio finding 3 (loopback bind) and finding 5 (`GET /status`) still open — see
+  `../clio-ai-assitant/docs/INFRA-HANDOFF.md`.
+- Deferred minors are listed in the ledger for the final review to triage.

--- a/docs/superpowers/specs/2026-07-26-formava-vps-infra-design.md
+++ b/docs/superpowers/specs/2026-07-26-formava-vps-infra-design.md
@@ -118,6 +118,49 @@ come from the cron inbox processor, not from the capture endpoint. Placing nginx
 in front of Clio fixes this gap as a side effect — nginx access logs record
 source IPs for every capture request.
 
+**Full inbound surface on port 3000** (verified against Clio source). Every route
+below is currently reachable from the open internet:
+
+```
+GET  /health                    unauthenticated
+GET  /status                    unauthenticated
+POST /capture                   ← the only route the Shortcut uses
+POST /capture/bulk
+POST /capture/:id/fix
+POST /capture/fix
+POST /capture/fix/recent
+POST /api/sessions              ┐
+POST /api/sessions/:id/input    │ drives an Anthropic-backed Orchestrator
+GET  /api/sessions/:id/state    │ with filesystem access to the vault
+POST /api/sessions/:id/chat     ┘
+```
+
+**A single token guards all of them.** `verifyToken(token, config.token)` where
+`config.token` → `config.apiToken` → `process.env.CAPTURE_API_TOKEN`
+(`src/index.ts:59`, `:227`). The sessions router is active in production —
+`src/index.ts:172–222` constructs the `orchestrator`, `sessionManager`, and
+`commandRouter` its conditional mount requires.
+
+This escalates the severity of the cleartext transmission. The credential
+crossing cellular networks on every dictation is the same credential that
+authorizes `POST /api/sessions/:id/chat`. Token capture means agent control, not
+merely note injection.
+
+Related footgun: `process.env.CAPTURE_API_TOKEN || 'dev-token'`
+(`src/index.ts:59`) silently degrades to a hardcoded token if the environment
+variable is absent, rather than refusing to start. Same family as Formava's
+`_create_mock_database()` (§3.4).
+
+**Telegram is not an inbound surface.** `src/channels/telegram.ts:1771` uses
+Telegraf long polling (`bot.launch()`) — the bot calls out to Telegram's API and
+receives nothing inbound. It requires no ingress, no vhost, and no open port, and
+is unaffected by binding Clio to loopback. Authorization is by
+`TELEGRAM_ALLOWED_IDS`, independent of the capture token. Recorded here so this
+is not later "fixed" by opening a port that was never needed.
+
+Existing app-layer controls worth preserving: `securityMiddleware()`,
+`captureRateLimiter` on `/capture`, and `express.json({ limit: '10kb' })`.
+
 **Confirmed client contract** (verified from the Shortcut definition):
 
 | Property | Value |
@@ -136,9 +179,17 @@ source IPs for every capture request.
   append-only logs that are routinely mined for subdomain enumeration. A
   personal tool belongs in a personal domain's public record, not the product's.
 
-Because the client uses exactly one path and one method, the vhost can be an
-allowlist rather than a proxy-everything block. Everything Clio currently exposes
-other than `/capture` stops being reachable from the internet:
+Because the client uses exactly one path and one method, the vhost is an
+**allowlist, and this is a security control rather than tidiness.** With an
+exact-match location, the agent-driving `/api/sessions/*` routes become
+unreachable from the internet *even with a valid token*. TLS protects the
+credential in transit; the allowlist bounds what the credential can reach if it
+leaks anyway. Neither measure alone is sufficient, because the token is also
+stored in plaintext in an iCloud-synced Shortcut.
+
+`client_max_body_size 64k` is a deliberately looser outer bound than Clio's own
+`express.json({ limit: '10kb' })` — nginx rejects the absurd, Express enforces the
+real limit. Defence in depth, not duplication.
 
 ```nginx
 limit_req_zone $binary_remote_addr zone=capture:1m rate=10r/m;
@@ -401,7 +452,11 @@ Exit criteria, expressed as a re-runnable assertion script:
 ✓ curl -X POST https://clio.lantzbuilds.com/capture  → 401 without token
 ✓ curl https://clio.lantzbuilds.com/v404/exec        → 404 from nginx, not Clio
 ✓ curl -X GET  https://clio.lantzbuilds.com/capture  → 403 (limit_except)
+✓ POST /api/sessions with a VALID token              → 404 from nginx
+    (proves the allowlist bounds a leaked credential)
+✓ GET  /status with a valid token                    → 404 from nginx
 ✓ iOS Shortcut capture end-to-end      → transcript lands in Clio inbox
+✓ Telegram bot still responds          → long polling unaffected by loopback bind
 ✓ curl http://144.202.88.7:3000/       → connection refused
 ✓ systemctl is-active postgresql formava-api formava-web clio nginx
 ✓ ufw status                           → 22, 80, 443 only

--- a/docs/superpowers/specs/2026-07-26-formava-vps-infra-design.md
+++ b/docs/superpowers/specs/2026-07-26-formava-vps-infra-design.md
@@ -1,0 +1,375 @@
+# Spec 1 — Formava VPS Infrastructure + Datastore
+
+**Date:** 2026-07-26
+**Status:** Approved for planning
+**Scope:** Provision the Vultr VPS to host Formava, stand up Postgres 16 + pgvector,
+establish TLS and process supervision, and prove the full request chain with a
+`/health` payload. Remediate security exposures found during assessment.
+
+---
+
+## 1. Why this spec exists
+
+Formava currently runs on Render as three `starter`-plan services (production,
+staging, and a staging CouchDB), with production persistence on IBM Cloudant's
+free tier. The goal is to consolidate onto an existing Vultr VPS that already
+hosts the Clio assistant, then perform substantial refactoring.
+
+This is Spec 1 of four. It deliberately contains **no application code migration**.
+
+### Decomposition
+
+| # | Spec | Scope | Depends on |
+|---|------|-------|------------|
+| **1** | **VPS infra + datastore** (this doc) | Postgres 16 + pgvector, systemd, nginx + TLS, deploy tooling, `/health` payload, security remediation | — |
+| 2 | Persistence swap | Repository interface, SQLAlchemy models from existing Pydantic models, Alembic baseline, delete `views.py` + `couchdb` + `chromadb`, re-embed into pgvector | 1 |
+| 3 | LLM provider seam | `app/services/llm/` package, split `openai_service.py`, provider-aware tokenization | 1 (parallel with 2) |
+| 4 | REST API + Next.js BFF | FastAPI routes over surviving services, cookie auth, Next App Router, delete Gradio layer | 2, 3 |
+
+### Guiding constraint
+
+**Gradio is never deployed to the VPS.** It has no users worth protecting (one
+betatester, ever) and is slated for deletion in Spec 4. Porting ~3,400 lines of
+UI code to new infrastructure only to delete it is waste. Render remains live and
+untouched as the fallback until Spec 4 completes.
+
+---
+
+## 2. Measured current state
+
+All figures below were measured on the host, not estimated.
+
+### Host (post-resize, verified 2026-07-26)
+
+```
+Vultr · Ubuntu 24.04.4 LTS · 144.202.88.7 · hostname: lantzbuilds
+CPU      2 vCPU  Intel Xeon (Skylake) @ 2.0 GHz
+RAM      3.8 GiB total · 518 MiB used · 3.3 GiB available
+Swap     5.3 GiB · 0 B used (never touched)
+Disk     75 GB · 59 GB free (18% used)
+Runtimes Python 3.12.3 · Node v20.20.2 · nginx 1.24.0
+Absent   postgresql · certbot · docker
+```
+
+Package availability confirmed in Ubuntu 24.04 repositories — no third-party
+apt repos required:
+
+- `postgresql-16` → `16.14-0ubuntu0.24.04.1`
+- `postgresql-16-pgvector` → `0.6.0-1`
+
+### Existing tenant
+
+| Unit | Memory | Notes |
+|------|--------|-------|
+| `clio.service` | 128 MB peak (cgroup) | node, `Restart=on-failure`, `StartLimitBurst=5` |
+| `fail2ban` | 68 MB | **`sshd` jail only** — nginx unprotected |
+| `nginx` | ~10 MB | stock `default` site, no vhosts, no TLS |
+| snapd / postfix / ModemManager / udisks2 / watchdog | ~150 MB | trimmable |
+
+### Application coupling (measured)
+
+Total app code: **10,107 LOC**. Test coverage: **87 LOC in one file** (<1%).
+
+| Component | LOC | Fate |
+|-----------|-----|------|
+| `app/pages/*` | 2,750 | Deleted (Spec 4) |
+| `app/routes.py` | 683 | Deleted (Spec 4) — pure Gradio nav wiring, not HTTP routes |
+| `app/theme.py`, `app/config/state.py` | — | Deleted (Spec 4) |
+| `app/config/database.py` | 1,116 | Rewritten behind repository interface (Spec 2) |
+| `app/config/views.py` | 266 | **Deleted** (Spec 2) — JS map/reduce as Python strings; ports to nothing |
+| `app/services/hevy_api.py` | 1,022 | Survives unchanged |
+| `app/services/vector_store.py` | 844 | Rewritten for pgvector (Spec 2) |
+| `app/services/openai_service.py` | 752 | Split (Spec 3) |
+| `app/models/*` (Pydantic v2) | — | Survives; becomes schema source of truth |
+
+**There is no REST API in this codebase.** FastAPI is present only as Gradio 5's
+transitive dependency. The API layer is net-new work in Spec 4, not a port.
+
+---
+
+## 3. Security findings requiring remediation
+
+These were discovered during assessment and are in scope for this spec.
+
+### 3.1 Clio publicly exposed over plaintext HTTP — **critical**
+
+```
+ufw:   3000/tcp  ALLOW  Anywhere
+clio:  node listening on 0.0.0.0:3000
+nginx: no TLS, no certificates
+```
+
+Clio's capture API is reachable from the open internet with no transport
+encryption. `CAPTURE_API_TOKEN` crosses the network in cleartext on every
+request — sniffable in transit and replayable once captured.
+
+**The port is being actively probed.** Observed `GET /v404/exec` against Clio on
+port 3000 at 15:31:38 on 2026-07-26.
+
+**The API has never had a legitimate caller.** Every Clio log entry since boot is
+internal cron (`Processed 0 captures`, repeatedly). No external source IPs. This
+is consistent with `.env`, where `MS_TENANT_ID`, `NOTION_API_KEY`, and
+`SUNSAMA_API_KEY` are all commented out — no webhook integration is configured.
+
+**Resolution:** bind Clio to `127.0.0.1`, delete the ufw rule for 3000, access via
+SSH tunnel (`ssh -L 3000:localhost:3000`). Grant Clio no domain and no
+certificate. If webhook ingress is configured later, add `clio.lantzbuilds.com`
+at that point — deliberately *not* on `formava.io`, because Certificate
+Transparency logs are public and permanent, and would publish an internal tool
+in the product domain's record indefinitely.
+
+### 3.2 Unfiltered hostile scanning — **medium**
+
+261 unsolicited requests to nginx in ~24h, including `zgrab/0.x` (ZMap
+internet-wide scanner), a Dahua camera RCE probe (`GET /SDK/webLanguage`), and
+CGI path enumeration. fail2ban has only the `sshd` jail, so none of it is
+filtered.
+
+**Resolution:** add `nginx-badbots` and `nginx-http-auth` jails.
+
+### 3.3 Credential exposure — **high**
+
+`VPS_PASSWORD` and `CAPTURE_API_TOKEN` were transmitted in plaintext during
+assessment and are present in conversation logs. SSH currently permits password
+authentication.
+
+**Resolution:** rotate the VPS root password and `CAPTURE_API_TOKEN`; set
+`PasswordAuthentication no` (the `VPS_KEY_PATH` in `.env` is already configured).
+
+### 3.4 Silent database fallback — **medium**
+
+`app/config/database.py:112` — `_create_mock_database()` installs a hand-rolled
+in-memory dict when CouchDB is unreachable. The application starts healthy and
+serves an empty database instead of failing. On Render this could have masked
+outages indefinitely.
+
+**Resolution:** the `/health` endpoint delivered by this spec fails loudly on
+database unavailability. The pattern is not carried into the new persistence
+layer in Spec 2.
+
+---
+
+## 4. Target architecture
+
+```
+                        Internet
+                           │  ufw: 22, 80, 443 only
+                           ▼
+                  ┌──────────────────┐
+                  │  nginx 1.24      │  TLS (certbot), HTTP→HTTPS,
+                  │                  │  HSTS, security headers
+                  └──────────────────┘
+                     │
+       formava.io / www.formava.io
+                     │
+                     ▼
+       ┌──────────────────────────┐        ┌────────────────────────┐
+       │ Next.js BFF              │        │ Clio                   │
+       │ 127.0.0.1:3001           │        │ 127.0.0.1:3000         │
+       │ systemd: formava-web     │        │ systemd: clio          │
+       └──────────────────────────┘        │ (rebound from 0.0.0.0) │
+                     │                      │ no domain, SSH tunnel  │
+                     │ server-side fetch    └────────────────────────┘
+                     ▼
+       ┌──────────────────────────┐
+       │ FastAPI / uvicorn        │  no public vhost — BFF-only consumer
+       │ 127.0.0.1:8000           │
+       │ systemd: formava-api     │
+       └──────────────────────────┘
+                     │ unix socket
+                     ▼
+       ┌──────────────────────────┐
+       │ Postgres 16 + pgvector   │  loopback only, scram-sha-256
+       │ systemd: postgresql      │
+       └──────────────────────────┘
+```
+
+### Design decisions and rationale
+
+**Postgres + pgvector over MongoDB or CouchDB.** The queries Formava actually
+runs are analytical (`get_workout_stats`, `get_workout_progression`,
+`get_workouts_by_date_range`); the `rereduce` block in `views.py` hand-rolls SQL
+`GROUP BY`. CouchDB was originally chosen because Render offered a document store,
+not for its replication features — which are unused. Decisively, pgvector
+collapses `chromadb` into the same database, deleting `chroma-hnswlib` — the C++
+compile that forces `build-essential` into the Dockerfile and creates the
+build-time memory spike. One datastore instead of two, and Alembic provides real
+migrations where `recreate_all_design_documents()` provided redefinition.
+
+**Native systemd + venv on the VPS; Docker Compose for local development only.**
+Removing `chromadb` eliminates the native-compilation problem that made
+containers attractive. Native matches the pattern `scripts/deploy.sh` already
+uses for Clio, avoids ~100 MB of daemon overhead, and removes a layer of
+indirection when debugging. Compose is retained for local Postgres.
+
+**Python 3.12** (the system version) rather than installing 3.11. The existing
+3.11 pin exists largely because `chroma-hnswlib` does not build on 3.12 — and
+that dependency is being deleted. Using the system interpreter avoids
+maintaining a second runtime.
+
+**Node 20** to match the host; `frontend/Dockerfile` currently specifies
+`node:18-alpine`.
+
+**FastAPI receives no public vhost.** Under the BFF pattern the browser never
+calls it directly — Next.js does, server-side, over loopback. A public
+`api.formava.io` would add attack surface with no consumer. It can be added if a
+mobile or third-party client materialises.
+
+**`MemoryMax=` on both Formava units.** `clio.service` uses
+`Restart=on-failure` with `StartLimitBurst=5`, so five OOM kills inside 60
+seconds leaves Clio permanently dead. Capping Formava's units means the kernel
+terminates the capped unit rather than Clio, making co-tenancy failure
+non-catastrophic.
+
+### Memory budget
+
+| Component | RAM |
+|-----------|-----|
+| Existing baseline (Clio, nginx, fail2ban, OS) | 518 MB |
+| Postgres 16 (`shared_buffers=256MB`) | ~320 MB |
+| FastAPI (after deleting chromadb / onnxruntime / langchain) | ~250 MB |
+| Next.js standalone | ~120 MB |
+| **Total** | **~1.2 GB of 3.8 GB — 32%** |
+
+Leaves headroom to reintroduce a staging tier later if desired.
+
+---
+
+## 5. Deliverables
+
+### 5.1 DNS
+
+| Record | Type | Value |
+|--------|------|-------|
+| `formava.io` | A | 144.202.88.7 |
+| `www.formava.io` | A | 144.202.88.7 |
+
+No DNS record for Clio or for FastAPI.
+
+### 5.2 Provisioning (idempotent, re-runnable)
+
+- Install `postgresql-16`, `postgresql-16-pgvector`, `certbot`,
+  `python3-certbot-nginx`, `python3.12-venv`
+- Create `formava` database and role; `CREATE EXTENSION vector`
+- Tune `postgresql.conf` for 2 vCPU / 3.8 GB: `shared_buffers=256MB`,
+  `effective_cache_size=1GB`, `max_connections=50`
+- Postgres bound to loopback, `scram-sha-256` authentication
+
+### 5.3 Security remediation
+
+Implements §3 in full:
+
+- Rebind Clio to `127.0.0.1:3000`; `ufw delete allow 3000/tcp`
+- Rotate VPS root password and `CAPTURE_API_TOKEN`
+- `PasswordAuthentication no` in `sshd_config`; confirm key auth works **before**
+  applying
+- fail2ban: add `nginx-badbots` and `nginx-http-auth` jails
+- nginx: HTTP→HTTPS redirect, HSTS, `X-Content-Type-Options`,
+  `X-Frame-Options`, `Referrer-Policy`
+
+### 5.4 systemd units
+
+- `formava-api.service` — uvicorn on `127.0.0.1:8000`, venv interpreter,
+  `EnvironmentFile=/etc/formava/formava.env`, `Restart=on-failure`,
+  `MemoryMax=768M`
+- `formava-web.service` — `node server.js` on `127.0.0.1:3001`, same restart
+  policy, `MemoryMax=512M`
+
+Cap rationale: each ceiling sits roughly 3× above measured steady-state, so
+ordinary spikes do not trigger kills, while the combined cap (1,280 MB) plus
+Postgres (320 MB) plus existing baseline (518 MB) totals ~2.1 GB against 3.8 GB.
+A runaway in either Formava unit is therefore terminated by the kernel before it
+can pressure `clio.service` into its `StartLimitBurst=5` permanent-failure state.
+
+### 5.5 Thin-slice payload
+
+- Minimal FastAPI application exposing `GET /health`, asserting **both** Postgres
+  connectivity and presence of the `vector` extension, returning JSON
+- **Fails loudly.** No fallback, mock, or degraded mode — explicitly the inverse
+  of `_create_mock_database()`
+- Deploy the existing Next.js scaffold as-is with a BFF route handler that calls
+  `/health` server-side, proving the entire chain: TLS → nginx → Next → FastAPI →
+  Postgres
+- pytest coverage for the `/health` application against a Compose Postgres,
+  establishing the ≥80% standard on new code from the outset
+
+### 5.6 Deploy and operations
+
+- `scripts/deploy_vps.sh` — modelled on Clio's `scripts/deploy.sh` (rsync → venv
+  install → `systemctl restart`), with subcommands `deploy|sync|restart|logs|status`
+- Secrets in `/etc/formava/formava.env`, root-owned `0600`, referenced via
+  systemd `EnvironmentFile` — never rsynced, never committed
+- Nightly `pg_dump` via systemd timer to `/var/backups/formava`, 7-day retention
+- Replace both `echo "This would trigger Render deployment"` stubs in
+  `.github/workflows/ci.yml`
+- Build artifacts in CI, not on the host — `npm run build` for Next.js 15 wants
+  1.5–2 GB, which is affordable at 3.8 GB but needlessly contends with Clio
+
+---
+
+## 6. Verification
+
+Exit criteria, expressed as a re-runnable assertion script:
+
+```
+✓ curl -I http://formava.io            → 301 to https
+✓ curl https://formava.io/             → Next.js scaffold renders
+✓ curl https://formava.io/api/health   → {"db":"ok","pgvector":"0.6.0"}
+✓ systemctl is-active postgresql formava-api formava-web clio nginx
+✓ ufw status                           → 22, 80, 443 only
+✓ ss -tlnp                             → :3000, :3001, :8000 on 127.0.0.1 only
+✓ certbot renew --dry-run              → success
+✓ systemctl list-timers                → pg_dump timer scheduled
+✓ pg_dump artifact present in /var/backups/formava
+✓ ssh with password                    → refused
+✓ fail2ban-client status               → sshd, nginx-badbots, nginx-http-auth
+✓ systemctl show formava-api -p MemoryMax  → 805306368  (768M)
+✓ systemctl show formava-web -p MemoryMax  → 536870912  (512M)
+✓ free -h                              → total usage ≤ 1.5 GB
+```
+
+**Rollback:** Render remains live and unmodified throughout. This spec is not a
+cutover — if VPS work stalls, production is unaffected. Render is decommissioned
+only after Spec 4.
+
+---
+
+## 7. Out of scope
+
+- Database schema, tables, or migrations beyond `CREATE EXTENSION vector` (Spec 2)
+- Any Gradio deployment (never; deleted in Spec 4)
+- LLM provider changes (Spec 3)
+- Data migration from Cloudant — data loss is explicitly acceptable
+- A staging tier — dropped during migration; reintroduce later if wanted
+- `api.formava.io` — add only when a non-browser client exists
+
+---
+
+## 8. Direction recorded for later specs
+
+**Spec 3 (LLM seam)** — agreed direction, revisitable when that spec is written:
+define a provider `Protocol` with a single `OpenAICompatibleProvider`
+implementation covering OpenAI, OpenRouter, Together, Groq, vLLM, and Ollama.
+This covers the possible future of self-hosting an open model on a separate
+Vultr GPU instance, since vLLM and Ollama both speak the OpenAI wire protocol.
+Native providers (e.g. Anthropic) are added only when a native feature —
+prompt caching, extended thinking — justifies the adapter.
+
+Known leaks the seam must address regardless of provider:
+
+1. **Embedding dimensions are schema, not configuration.** A pgvector column is
+   declared `vector(N)` at DDL time. Changing embedding model requires an Alembic
+   migration plus a full re-embed. Cheap here — the corpus is a 69 KB checked-in
+   `hevy_exercise_ids.json` plus `bootstrap_vectorstore.py` — but the schema must
+   record which model produced the vectors so staleness is detectable.
+   *Verify before choosing a model:* pgvector's HNSW/IVFFlat indexes are believed
+   to cap at 2000 dimensions, which would exclude 3072-dim models at full width.
+2. **Tokenization.** `openai_service.py:501` calls
+   `tiktoken.encoding_for_model("gpt-4-turbo")`. This is OpenAI-specific BPE and
+   silently mis-counts against other model families.
+3. **Structured output.** `generate_routine` parses JSON from responses. The
+   abstraction should return validated Pydantic models, not raw strings.
+
+**Test coverage** is under 1% against 10,107 LOC. Specs 2–4 each carry their own
+coverage obligation; retrofitting at the end is not viable given two refactors
+that touch the LLM layer and delete the entire UI layer.

--- a/docs/superpowers/specs/2026-07-26-formava-vps-infra-design.md
+++ b/docs/superpowers/specs/2026-07-26-formava-vps-infra-design.md
@@ -106,17 +106,43 @@ request — sniffable in transit and replayable once captured.
 **The port is being actively probed.** Observed `GET /v404/exec` against Clio on
 port 3000 at 15:31:38 on 2026-07-26.
 
-**The API has never had a legitimate caller.** Every Clio log entry since boot is
-internal cron (`Processed 0 captures`, repeatedly). No external source IPs. This
-is consistent with `.env`, where `MS_TENANT_ID`, `NOTION_API_KEY`, and
-`SUNSAMA_API_KEY` are all commented out — no webhook integration is configured.
+**The endpoint has a real external caller:** an iOS Shortcut performs
+on-device speech-to-text and POSTs the transcript to the capture API. The token
+therefore crosses cellular and public wireless networks in cleartext on every
+capture. This is the highest-severity item in this spec.
 
-**Resolution:** bind Clio to `127.0.0.1`, delete the ufw rule for 3000, access via
-SSH tunnel (`ssh -L 3000:localhost:3000`). Grant Clio no domain and no
-certificate. If webhook ingress is configured later, add `clio.lantzbuilds.com`
-at that point — deliberately *not* on `formava.io`, because Certificate
-Transparency logs are public and permanent, and would publish an internal tool
-in the product domain's record indefinitely.
+Note on observability: Clio's request log records method and path but **not
+source IP** (`[timestamp] GET /path`). Absence of source IPs in the log is not
+evidence of absence of callers, and the periodic `Processed 0 captures` lines
+come from the cron inbox processor, not from the capture endpoint. Placing nginx
+in front of Clio fixes this gap as a side effect — nginx access logs record
+source IPs for every capture request.
+
+**Resolution:** terminate TLS at nginx and bind Clio to loopback.
+
+- `clio.lantzbuilds.com` → nginx (TLS) → `127.0.0.1:3000`
+- Deliberately **not** `clio.formava.io`. Certificate Transparency logs are
+  public and permanent; every hostname in a certificate is published to
+  append-only logs that are routinely mined for subdomain enumeration. A
+  personal tool belongs in a personal domain's public record, not the product's.
+- `limit_req` rate limiting on the capture route — it is a token-authenticated
+  POST endpoint on the open internet
+- fail2ban jail on repeated `401` responses against the capture route
+
+**Cutover sequence — capture must not break.** The iOS Shortcut is the only
+client and cannot be updated remotely, so ordering matters:
+
+1. Add the `clio.lantzbuilds.com` A record
+2. nginx vhost + certbot, `proxy_pass` to `127.0.0.1:3000`. Clio is still bound
+   to `0.0.0.0`, which includes loopback, so the old direct path and the new
+   HTTPS path both work simultaneously
+3. Update the Shortcut to the HTTPS URL; verify a real capture lands end to end
+4. Rotate `CAPTURE_API_TOKEN`; update the Shortcut's token; verify again
+5. **Only then** rebind Clio to `127.0.0.1` and `ufw delete allow 3000/tcp`.
+   The direct plaintext path dies; the HTTPS path is unaffected
+
+Steps 3 and 4 require manual action on the phone. Do not perform step 5 until
+step 4 is verified, or captures fail silently.
 
 ### 3.2 Unfiltered hostile scanning — **medium**
 
@@ -157,19 +183,21 @@ layer in Spec 2.
                            ▼
                   ┌──────────────────┐
                   │  nginx 1.24      │  TLS (certbot), HTTP→HTTPS,
-                  │                  │  HSTS, security headers
+                  │                  │  HSTS, security headers,
+                  │                  │  limit_req on capture route
                   └──────────────────┘
-                     │
-       formava.io / www.formava.io
-                     │
-                     ▼
-       ┌──────────────────────────┐        ┌────────────────────────┐
-       │ Next.js BFF              │        │ Clio                   │
-       │ 127.0.0.1:3001           │        │ 127.0.0.1:3000         │
-       │ systemd: formava-web     │        │ systemd: clio          │
-       └──────────────────────────┘        │ (rebound from 0.0.0.0) │
-                     │                      │ no domain, SSH tunnel  │
-                     │ server-side fetch    └────────────────────────┘
+                     │                              │
+       formava.io / www.formava.io      clio.lantzbuilds.com
+                     │                              │
+                     ▼                              ▼
+       ┌──────────────────────────┐   ┌────────────────────────────┐
+       │ Next.js BFF              │   │ Clio                       │
+       │ 127.0.0.1:3001           │   │ 127.0.0.1:3000             │
+       │ systemd: formava-web     │   │ systemd: clio              │
+       └──────────────────────────┘   │ (rebound from 0.0.0.0)     │
+                     │                 │ caller: iOS Shortcut       │
+                     │ server-side      │ (on-device STT → POST)     │
+                     │ fetch            └────────────────────────────┘
                      ▼
        ┌──────────────────────────┐
        │ FastAPI / uvicorn        │  no public vhost — BFF-only consumer
@@ -239,12 +267,13 @@ Leaves headroom to reintroduce a staging tier later if desired.
 
 ### 5.1 DNS
 
-| Record | Type | Value |
-|--------|------|-------|
-| `formava.io` | A | 144.202.88.7 |
-| `www.formava.io` | A | 144.202.88.7 |
+| Record | Type | Value | Serves |
+|--------|------|-------|--------|
+| `formava.io` | A | 144.202.88.7 | Next.js BFF |
+| `www.formava.io` | A | 144.202.88.7 | redirect to apex |
+| `clio.lantzbuilds.com` | A | 144.202.88.7 | Clio capture API (iOS Shortcut) |
 
-No DNS record for Clio or for FastAPI.
+No DNS record for FastAPI — it is reachable only from the BFF over loopback.
 
 ### 5.2 Provisioning (idempotent, re-runnable)
 
@@ -259,11 +288,16 @@ No DNS record for Clio or for FastAPI.
 
 Implements §3 in full:
 
-- Rebind Clio to `127.0.0.1:3000`; `ufw delete allow 3000/tcp`
-- Rotate VPS root password and `CAPTURE_API_TOKEN`
+- Put Clio behind nginx TLS at `clio.lantzbuilds.com`, then rebind to
+  `127.0.0.1:3000` and `ufw delete allow 3000/tcp` — **following the five-step
+  cutover sequence in §3.1**, which must not be reordered
+- Rotate VPS root password and `CAPTURE_API_TOKEN` (the latter paired with the
+  iOS Shortcut update, per §3.1 step 4)
 - `PasswordAuthentication no` in `sshd_config`; confirm key auth works **before**
   applying
-- fail2ban: add `nginx-badbots` and `nginx-http-auth` jails
+- nginx `limit_req` zone on the Clio capture route
+- fail2ban: add `nginx-badbots` and `nginx-http-auth` jails, plus a jail matching
+  repeated `401` responses on the capture route
 - nginx: HTTP→HTTPS redirect, HSTS, `X-Content-Type-Options`,
   `X-Frame-Options`, `Referrer-Policy`
 
@@ -315,10 +349,14 @@ Exit criteria, expressed as a re-runnable assertion script:
 ✓ curl -I http://formava.io            → 301 to https
 ✓ curl https://formava.io/             → Next.js scaffold renders
 ✓ curl https://formava.io/api/health   → {"db":"ok","pgvector":"0.6.0"}
+✓ curl -I https://clio.lantzbuilds.com → 200/401, valid cert
+✓ iOS Shortcut capture end-to-end      → transcript lands in Clio inbox
+✓ curl http://144.202.88.7:3000/       → connection refused
 ✓ systemctl is-active postgresql formava-api formava-web clio nginx
 ✓ ufw status                           → 22, 80, 443 only
 ✓ ss -tlnp                             → :3000, :3001, :8000 on 127.0.0.1 only
-✓ certbot renew --dry-run              → success
+✓ certbot renew --dry-run              → success (all three hostnames)
+✓ nginx access log                     → source IPs now recorded for captures
 ✓ systemctl list-timers                → pg_dump timer scheduled
 ✓ pg_dump artifact present in /var/backups/formava
 ✓ ssh with password                    → refused

--- a/docs/superpowers/specs/2026-07-26-formava-vps-infra-design.md
+++ b/docs/superpowers/specs/2026-07-26-formava-vps-infra-design.md
@@ -229,8 +229,16 @@ server {
 
     client_max_body_size 64k;
 
-    # iOS Shortcut — capture only, POST only
+    # iOS Shortcut — new capture
     location = /capture {
+        limit_except POST { deny all; }
+        limit_req zone=capture burst=5 nodelay;
+        proxy_pass http://127.0.0.1:3000;
+    }
+
+    # iOS Shortcut — correct an existing capture by id.
+    # Regex, because an exact match cannot cover a path parameter.
+    location ~ ^/capture/[^/]+/fix$ {
         limit_except POST { deny all; }
         limit_req zone=capture burst=5 nodelay;
         proxy_pass http://127.0.0.1:3000;
@@ -263,11 +271,27 @@ Server-Sent Events (`cli/src/http/stream.ts`). With nginx's default
 the CLI would hang until the whole reply completed, then dump it at once. The
 default 60s `proxy_read_timeout` would also sever long agent turns.
 
-Still closed to the internet: `/status`, `/capture/bulk`, `/capture/:id/fix`,
-`/capture/fix`, `/capture/fix/recent`. The `GET /v404/exec` probe observed on
-2026-07-26 is answered by nginx with a flat 404 and never touches the Node
-process. If a route turns out to be needed, nginx logs the 404 with its exact
-path — a loud, one-line fix.
+**Why a regex and not `location /capture/`.** A prefix match on `/capture/` would
+also publish `/capture/bulk`, `/capture/fix`, and `/capture/fix/recent`. The
+anchored pattern `^/capture/[^/]+/fix$` requires exactly three segments, so
+`/capture/fix` (two segments) and `/capture/fix/recent` (`[^/]+` would have to be
+`fix`, leaving `/recent` unmatched against `/fix$`) both still fall through to the
+404. Precedence works out because nginx evaluates regex locations before plain
+prefix matches, so `location /` never sees these.
+
+Still closed to the internet: `GET /status`, `/capture/bulk`, `/capture/fix`,
+`/capture/fix/recent`.
+
+Note on `/status`: the Telegram `/status` command is handled by the bot's own
+command router over long polling and never touches HTTP. It is unrelated to the
+unauthenticated `GET /status` route at `src/api/capture.ts:81`, which has no
+identified external caller and therefore stays closed — desirable, given it is
+unauthenticated.
+
+The `GET /v404/exec` probe observed on 2026-07-26 is answered by nginx with a flat
+404 and never touches the Node process. If `/capture/fix` or
+`/capture/fix/recent` turn out to back a second Shortcut, nginx logs the 404 with
+its exact path — a loud, one-line fix.
 
 - fail2ban jail on repeated `401` responses against the capture route
 
@@ -508,9 +532,12 @@ Exit criteria, expressed as a re-runnable assertion script:
 ✓ curl -X POST https://clio.lantzbuilds.com/capture  → 401 without token
 ✓ curl https://clio.lantzbuilds.com/v404/exec        → 404 from nginx, not Clio
 ✓ curl -X GET  https://clio.lantzbuilds.com/capture  → 403 (limit_except)
-✓ POST /api/sessions with a VALID token              → 404 from nginx
-    (proves the allowlist bounds a leaked credential)
-✓ GET  /status with a valid token                    → 404 from nginx
+✓ POST /capture/<id>/fix                             → reaches Clio (401/200)
+✓ POST /capture/fix   with a VALID token             → 404 from nginx
+✓ POST /capture/bulk  with a VALID token             → 404 from nginx
+✓ GET  /status        with a VALID token             → 404 from nginx
+    (the valid-token cases prove the allowlist bounds a leaked credential)
+✓ iOS "fix" Shortcut end-to-end                      → correction applies
 ✓ iOS Shortcut capture end-to-end      → transcript lands in Clio inbox
 ✓ Telegram bot still responds          → long polling unaffected by loopback bind
 ✓ curl http://144.202.88.7:3000/       → connection refused

--- a/docs/superpowers/specs/2026-07-26-formava-vps-infra-design.md
+++ b/docs/superpowers/specs/2026-07-26-formava-vps-infra-design.md
@@ -118,6 +118,16 @@ come from the cron inbox processor, not from the capture endpoint. Placing nginx
 in front of Clio fixes this gap as a side effect — nginx access logs record
 source IPs for every capture request.
 
+**Confirmed client contract** (verified from the Shortcut definition):
+
+| Property | Value |
+|----------|-------|
+| URL | `http://144.202.88.7:3000/capture` — held in a discrete URL action, so the cutover is a single field edit |
+| Method | `POST` only |
+| Headers | `Authorization: Bearer <CAPTURE_API_TOKEN>`, `Content-Type: application/json` |
+| Body | JSON containing dictated text — kilobytes at most |
+| Frequency | Human-paced dictation; a handful per hour at most |
+
 **Resolution:** terminate TLS at nginx and bind Clio to loopback.
 
 - `clio.lantzbuilds.com` → nginx (TLS) → `127.0.0.1:3000`
@@ -125,24 +135,61 @@ source IPs for every capture request.
   public and permanent; every hostname in a certificate is published to
   append-only logs that are routinely mined for subdomain enumeration. A
   personal tool belongs in a personal domain's public record, not the product's.
-- `limit_req` rate limiting on the capture route — it is a token-authenticated
-  POST endpoint on the open internet
+
+Because the client uses exactly one path and one method, the vhost can be an
+allowlist rather than a proxy-everything block. Everything Clio currently exposes
+other than `/capture` stops being reachable from the internet:
+
+```nginx
+limit_req_zone $binary_remote_addr zone=capture:1m rate=10r/m;
+
+server {
+    listen 443 ssl;
+    server_name clio.lantzbuilds.com;
+
+    client_max_body_size 64k;          # dictated text is small
+
+    location = /capture {              # exact match, not prefix
+        limit_except POST { deny all; }
+        limit_req zone=capture burst=5 nodelay;
+        proxy_pass http://127.0.0.1:3000;
+    }
+
+    location / { return 404; }         # probes never reach Clio
+}
+```
+
+The `GET /v404/exec` probe observed on 2026-07-26 would be answered by nginx with
+a flat 404 and never touch the Node process.
+
 - fail2ban jail on repeated `401` responses against the capture route
 
 **Cutover sequence — capture must not break.** The iOS Shortcut is the only
 client and cannot be updated remotely, so ordering matters:
 
-1. Add the `clio.lantzbuilds.com` A record
+1. Add the `clio.lantzbuilds.com` A record. **Confirm propagation before
+   proceeding** (`dig +short clio.lantzbuilds.com`) — certbot's HTTP-01 challenge
+   fails against a stale record, and the failure looks like a config error
 2. nginx vhost + certbot, `proxy_pass` to `127.0.0.1:3000`. Clio is still bound
    to `0.0.0.0`, which includes loopback, so the old direct path and the new
    HTTPS path both work simultaneously
-3. Update the Shortcut to the HTTPS URL; verify a real capture lands end to end
-4. Rotate `CAPTURE_API_TOKEN`; update the Shortcut's token; verify again
+3. Edit the Shortcut's URL action → `https://clio.lantzbuilds.com/capture`;
+   dictate a real capture and confirm it lands in the Clio inbox
+4. Rotate `CAPTURE_API_TOKEN` in `/opt/clio/.env`, restart Clio, update the
+   Shortcut's `Authorization` header; verify a capture again
 5. **Only then** rebind Clio to `127.0.0.1` and `ufw delete allow 3000/tcp`.
    The direct plaintext path dies; the HTTPS path is unaffected
 
 Steps 3 and 4 require manual action on the phone. Do not perform step 5 until
 step 4 is verified, or captures fail silently.
+
+Two notes on the Shortcut: iOS validates TLS properly on `Get contents of URL`,
+so a Let's Encrypt certificate needs no special handling. And the token lives in
+plaintext inside the Shortcut, which syncs via iCloud — acceptable for this
+threat model, but a reason to keep the token's scope limited to capture only.
+
+HSTS on this vhost should **not** use `includeSubDomains` or `preload`, to avoid
+constraining unrelated `lantzbuilds.com` hosts.
 
 ### 3.2 Unfiltered hostile scanning — **medium**
 
@@ -295,7 +342,9 @@ Implements §3 in full:
   iOS Shortcut update, per §3.1 step 4)
 - `PasswordAuthentication no` in `sshd_config`; confirm key auth works **before**
   applying
-- nginx `limit_req` zone on the Clio capture route
+- Clio vhost as an allowlist: `location = /capture` with `limit_except POST`,
+  `limit_req` at 10r/m burst 5, `client_max_body_size 64k`, and `location / →
+  404` (full block in §3.1)
 - fail2ban: add `nginx-badbots` and `nginx-http-auth` jails, plus a jail matching
   repeated `401` responses on the capture route
 - nginx: HTTP→HTTPS redirect, HSTS, `X-Content-Type-Options`,
@@ -349,7 +398,9 @@ Exit criteria, expressed as a re-runnable assertion script:
 ✓ curl -I http://formava.io            → 301 to https
 ✓ curl https://formava.io/             → Next.js scaffold renders
 ✓ curl https://formava.io/api/health   → {"db":"ok","pgvector":"0.6.0"}
-✓ curl -I https://clio.lantzbuilds.com → 200/401, valid cert
+✓ curl -X POST https://clio.lantzbuilds.com/capture  → 401 without token
+✓ curl https://clio.lantzbuilds.com/v404/exec        → 404 from nginx, not Clio
+✓ curl -X GET  https://clio.lantzbuilds.com/capture  → 403 (limit_except)
 ✓ iOS Shortcut capture end-to-end      → transcript lands in Clio inbox
 ✓ curl http://144.202.88.7:3000/       → connection refused
 ✓ systemctl is-active postgresql formava-api formava-web clio nginx

--- a/docs/superpowers/specs/2026-07-26-formava-vps-infra-design.md
+++ b/docs/superpowers/specs/2026-07-26-formava-vps-infra-design.md
@@ -191,27 +191,83 @@ stored in plaintext in an iCloud-synced Shortcut.
 `express.json({ limit: '10kb' })` — nginx rejects the absurd, Express enforces the
 real limit. Defence in depth, not duplication.
 
+### 3.1.1 Coordinated dependency — token splitting (Clio-side)
+
+The Clio CLI is a genuine HTTP client (`cli/` is a separate package from `src/`).
+`cli/src/http/client.ts` and `cli/src/http/stream.ts` call a configured
+`vpsUrl` over the network; `cli/src/config/store.ts` already validates and accepts
+`https://` URLs, so retargeting is `clio config set-url https://clio.lantzbuilds.com`.
+
+CLI route requirements: `GET /health`, `POST /api/sessions`,
+`POST /api/sessions/:id/input`, `GET /api/sessions/:id/state`,
+`POST /api/sessions/:id/chat` (SSE), `DELETE /api/sessions/:id`.
+
+`/api/sessions/*` must therefore be publicly reachable. Combined with the single
+shared token, that means **the credential sniffable from the iOS Shortcut's
+cleartext traffic also grants remote agent control.** Two independent fixes:
+
+| Fix | Removes | Owner |
+|-----|---------|-------|
+| TLS on the vhost | the sniffing vector | Spec 1 (this doc) |
+| Split capture-scoped and session-scoped tokens | the blast radius if a token leaks | Clio development |
+
+**TLS is the more urgent of the two and does not depend on the split.** Spec 1
+proceeds independently. The split is tracked in the Clio handoff at
+`docs/INFRA-HANDOFF.md` in the Clio repository.
+
+Sequencing note: if the Clio session implements token splitting, coordinate so
+`CAPTURE_API_TOKEN` rotation (§3.1 step 4) happens **once**, not twice — the iOS
+Shortcut requires a manual edit each time.
+
 ```nginx
-limit_req_zone $binary_remote_addr zone=capture:1m rate=10r/m;
+limit_req_zone $binary_remote_addr zone=capture:1m  rate=10r/m;
+limit_req_zone $binary_remote_addr zone=sessions:1m rate=60r/m;
 
 server {
-    listen 443 ssl;
+    listen 443 ssl http2;              # nginx 1.24 form; 1.25.1+ uses `http2 on;`
     server_name clio.lantzbuilds.com;
 
-    client_max_body_size 64k;          # dictated text is small
+    client_max_body_size 64k;
 
-    location = /capture {              # exact match, not prefix
+    # iOS Shortcut — capture only, POST only
+    location = /capture {
         limit_except POST { deny all; }
         limit_req zone=capture burst=5 nodelay;
         proxy_pass http://127.0.0.1:3000;
+    }
+
+    # CLI connection validation
+    location = /health {
+        proxy_pass http://127.0.0.1:3000;
+    }
+
+    # CLI session control — SSE-aware
+    location /api/sessions {
+        limit_req zone=sessions burst=20 nodelay;
+        proxy_pass http://127.0.0.1:3000;
+
+        proxy_http_version 1.1;
+        proxy_set_header Connection '';
+        proxy_buffering off;           # SSE: stream, never buffer
+        proxy_cache off;
+        proxy_read_timeout 120s;       # client aborts at 60s
     }
 
     location / { return 404; }         # probes never reach Clio
 }
 ```
 
-The `GET /v404/exec` probe observed on 2026-07-26 would be answered by nginx with
-a flat 404 and never touch the Node process.
+**The SSE settings are load-bearing.** `POST /api/sessions/:id/chat` streams
+Server-Sent Events (`cli/src/http/stream.ts`). With nginx's default
+`proxy_buffering on`, the response is buffered and typewriter rendering breaks —
+the CLI would hang until the whole reply completed, then dump it at once. The
+default 60s `proxy_read_timeout` would also sever long agent turns.
+
+Still closed to the internet: `/status`, `/capture/bulk`, `/capture/:id/fix`,
+`/capture/fix`, `/capture/fix/recent`. The `GET /v404/exec` probe observed on
+2026-07-26 is answered by nginx with a flat 404 and never touches the Node
+process. If a route turns out to be needed, nginx logs the 404 with its exact
+path — a loud, one-line fix.
 
 - fail2ban jail on repeated `401` responses against the capture route
 

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -38,4 +38,3 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
-next-env.d.ts

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,5 @@
-# Use Node.js 18 Alpine image
-FROM node:18-alpine AS base
+# Use Node.js 20 Alpine image
+FROM node:20-alpine AS base
 
 # Install dependencies only when needed
 FROM base AS deps

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Emits .next/standalone with a self-contained server.js — required by
+  // formava-web.service and by the multi-stage Dockerfile.
+  output: "standalone",
 };
 
 export default nextConfig;

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,0 +1,6222 @@
+{
+  "name": "formava-frontend",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "formava-frontend",
+      "version": "0.1.0",
+      "dependencies": {
+        "next": "^15.1.6",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      },
+      "devDependencies": {
+        "@eslint/eslintrc": "^3.2.0",
+        "@tailwindcss/postcss": "^4.0.0",
+        "@types/node": "^20.17.16",
+        "@types/react": "^19.0.8",
+        "@types/react-dom": "^19.0.3",
+        "eslint": "^9.19.0",
+        "eslint-config-next": "^15.1.6",
+        "tailwindcss": "^4.0.0",
+        "typescript": "^5.7.3"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.3",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.3.tgz",
+      "integrity": "sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/config-array": {
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/object-schema": "^2.1.7",
+        "debug": "^4.3.1",
+        "minimatch": "^3.1.5"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/config-helpers": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/core": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/json-schema": "^7.0.15"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
+      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.14.0",
+        "debug": "^4.3.2",
+        "espree": "^10.0.1",
+        "globals": "^14.0.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.3.0",
+        "minimatch": "^3.1.5",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
+      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      }
+    },
+    "node_modules/@eslint/object-schema": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@eslint/plugin-kit": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0",
+        "levn": "^0.4.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@humanfs/core": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/node": {
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
+        "@humanwhocodes/retry": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/retry": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+      "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.7.0"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.22.tgz",
+      "integrity": "sha512-O5BlKb3KtsHkvO0gjjV66PuJnAgCtIEIzwkt50HRAHsQkU1t77eksIXSZV84/WMtZJjWrnDUPKHVRi0D62nSAA==",
+      "license": "MIT"
+    },
+    "node_modules/@next/eslint-plugin-next": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.5.22.tgz",
+      "integrity": "sha512-SB8PGBmpAiVmOtMOIfObnI2VA3MN3jUGg0iYTh4MO2efxQIV/IL0U8iYOok/8DldCEKARyCOJJix+Vvgzaic/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "3.3.1"
+      }
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-15.5.22.tgz",
+      "integrity": "sha512-/VISwtffSg8+fVvBbXdglsvruCsdbBC4dG25iU6xascKVqfQKsj/OtjGnOEkIS7pX5GB9e9/r5QprpicsGL3gw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-15.5.22.tgz",
+      "integrity": "sha512-NiA9ve8hbiuhG/Q17a2mZDRVxMTtg3rTOgjLnDaLlE+AEPAQlkkuKrfePEbeOrgYmX0U2KGX4EVEn09hXU5GlQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-15.5.22.tgz",
+      "integrity": "sha512-vAPa9vltW+UW/KWtjXeSUFgV3wb1x9d/BeyC6WFI6eBpL0D2f70oGwtOp6193mNW3qusrpgBzMQferPf+Zh8Dw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-15.5.22.tgz",
+      "integrity": "sha512-iknK80pWlNDnkdSr13bd8mMuG3Z2oTxODwsZHvuMY7caMk77+rBLdHVWsy8v2EVa3ZojJ/+wJX5fnq8va6Gv8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-15.5.22.tgz",
+      "integrity": "sha512-penuEdkwU2OOAiS+n4LE8T/VIoCfAI01QcLZTJ2xc3+l4Q22L/DzURocmI2LU1b+8BMQoLAP1Sze3uYAZT05Bg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-15.5.22.tgz",
+      "integrity": "sha512-ZM0BKJm3FZ+guG6WT6PcyOLtp6paZ5tngcJC/uUKvLW4Y0TQnnVi1+UGdo8Q6Yxp5gaS82pmC1rD/oFlhkWB3g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-15.5.22.tgz",
+      "integrity": "sha512-rY/YaumrZaS0//94BnHLF5VSRp0GFUO4GvXNuoCBb0cGSci96yO+p1JaNL2aq9YZAYv9cuZRziV02x5IQH/wjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-15.5.22.tgz",
+      "integrity": "sha512-s5IA4cyrbR2XK/5NWcu5dp8CfPBiKME+UhvNperia7uQybEgg5+LIhGMiY37WQE4rcI4owsDcU4IVUjLoTuDkA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nolyfill/is-core-module": {
+      "version": "1.0.39",
+      "resolved": "https://registry.npmjs.org/@nolyfill/is-core-module/-/is-core-module-1.0.39.tgz",
+      "integrity": "sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@rtsao/scc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
+      "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rushstack/eslint-patch": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
+      "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "^5.24.1",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.3.tgz",
+      "integrity": "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "postcss": "^8.5.16",
+        "tailwindcss": "4.3.3"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.65.0.tgz",
+      "integrity": "sha512-IEgob78X12rHpUmtcwFsXhZdVGJtwTVP8FiCLZkR6GlYVrl2PcuB+KhCE5BlVC/eQpQnu8WXRtkHZuPar+gCRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/type-utils": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.65.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.65.0.tgz",
+      "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.65.0.tgz",
+      "integrity": "sha512-SxnPhbTsGahizDgbu7oqFH/xVtzIqMd/s+WtnSxNxJZJpLbdT5IPdzg8EZxO3+PoKahXmwJLeNQOpKJb3/bi7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.65.0",
+        "@typescript-eslint/types": "^8.65.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.65.0.tgz",
+      "integrity": "sha512-Esbl8OSYiVxBokYgWPf7VVWg/BE798wXhimnn9ML9Pt5qoDf8bfQlgjlKXR/k98+AcNzlLKYrpCcrcuZ9DZLgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.65.0.tgz",
+      "integrity": "sha512-j6GzGqCiRdA7Qhur2VVmKZAkBLfnHFQfx4TaJGL9RMveZqCo48jSHHO0DTgizEnGhtWnqmbtCUSrqSkdiY/0Hg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.65.0.tgz",
+      "integrity": "sha512-YjaZ7PRI5qY7ax2L3PbvX0rRyGtipAReCWs0mhhDBHjH/vl0g0BonaGXrKdKpMbIIsMIwDgbk/xzkBTyAltS5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0",
+        "@typescript-eslint/utils": "8.65.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.65.0.tgz",
+      "integrity": "sha512-JboAE2swaYt4tb1fHhHTABE2K+OLy09XfcTbhnk4Pw96f9dd2e9iYsJ28gBggHlo5z5x1rkyWvcPoTuNTd4oGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.65.0",
+        "@typescript-eslint/tsconfig-utils": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/visitor-keys": "8.65.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.65.0.tgz",
+      "integrity": "sha512-gXiwIHsYreboxeJucHKPvgwl7dXt50mF8s1/c00cP/WoVTyWKFdtfhRWwZiXYFU5H2O8vVoSLNrexFZjYS/SGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.65.0",
+        "@typescript-eslint/types": "8.65.0",
+        "@typescript-eslint/typescript-estree": "8.65.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.65.0.tgz",
+      "integrity": "sha512-8C71BQkGjiMmXtop7pHVJu1l2NNShFdkCyD6a2ezzs5vU/L3LRtb69EtcteFwz0mYMPzIgOw0n6OV4VBUWZd7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.65.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.12.2.tgz",
+      "integrity": "sha512-g5T90pqg1bo/7mytQx6F4iBNC0Wsh9cu+z9veDbFjc7HjpesJFWD7QMS0NGStXM075+7dJPPVvBbpZlnrdpi/w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.12.2.tgz",
+      "integrity": "sha512-YGCRZv/9GLhwmz6mYDeTsm/92BAyR28l6c2ReweVW5pWgfsitWLY8upvfRlGdoyD8HjeTHSYJWyZGD4KJA/nFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.12.2.tgz",
+      "integrity": "sha512-u9DiNT1auQMO20A9SyTuG3wUgQWB9Z7KjAg0uFuCDR1FsAY8A0CG2S6JpHS1xwm/w1G08bjXZDcyOCjv1WAm2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.12.2.tgz",
+      "integrity": "sha512-f7rPLi/T1HVKZu/u6t87lroib16n8vrSzcyxI7lg4BGO9UF26KhQL44sd9eOUgrTYhvRXtWOIZT5PejdPyJfUA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.12.2.tgz",
+      "integrity": "sha512-BpcOjWCJub6nRZUS2zA20pmLvjtqAtGejETaIyRLiZiQf++cbrjltLA5NN/xaXfqeOBOSlMFbemIl5/S5tljmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.12.2.tgz",
+      "integrity": "sha512-vZTDvdSISZjJx66OzJqtsOhzifbqRjbmI1Mnu49fQDwog5GtDI4QidRiEAYbZCRj9C8YZEW+3ZjqsyS9GR4k2A==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.12.2.tgz",
+      "integrity": "sha512-BiPI+IrIlwcW4nLLMM21+B1dFPzd55yAVgVGrdgDjNef+ch03GdxrcyaIz8X9SsQirh/kCQ7mviyWlMxdh2D7g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.12.2.tgz",
+      "integrity": "sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.12.2.tgz",
+      "integrity": "sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-gnu/-/resolver-binding-linux-loong64-gnu-1.12.2.tgz",
+      "integrity": "sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-loong64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-loong64-musl/-/resolver-binding-linux-loong64-musl-1.12.2.tgz",
+      "integrity": "sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.12.2.tgz",
+      "integrity": "sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.12.2.tgz",
+      "integrity": "sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.12.2.tgz",
+      "integrity": "sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.12.2.tgz",
+      "integrity": "sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.12.2.tgz",
+      "integrity": "sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.12.2.tgz",
+      "integrity": "sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-openharmony-arm64": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-openharmony-arm64/-/resolver-binding-openharmony-arm64-1.12.2.tgz",
+      "integrity": "sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.12.2.tgz",
+      "integrity": "sha512-tYFDIkMxSflfEc/h92ZWNsZlHSwgimbNHSO3PL2JWQHfCuC2q316jMyYU9TIWZsFK2bQwyK5VAdYgn8ygPj69A==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi/node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.12.2.tgz",
+      "integrity": "sha512-qzNyg3xL0VPQmCaUh+N5jSitce6k+uCBfMDesWRnlULOZaqUkaJ0ybdT+UqlAWJoQjuqfIU/0Ptx9bteN4D82g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.12.2.tgz",
+      "integrity": "sha512-WD9sY00OfpHVGfsnHZoA8jVT+esS/Bg8z8jzxp5BnDCjjwsuKsPQrzswwpFy4J1AUJbXPRfkpcX0mXrzeXW79g==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.12.2.tgz",
+      "integrity": "sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/acorn": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/array-buffer-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-buffer-byte-length/-/array-buffer-byte-length-1.0.2.tgz",
+      "integrity": "sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "is-array-buffer": "^3.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array-includes": {
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.9.tgz",
+      "integrity": "sha512-FmeCCAenzH0KH381SPT5FZmiA/TmpndpcaShhfgEN9eCVjnFBqq3l1xrI42y8+PPLI6hypzou4GXw00WHmPBLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.0",
+        "es-object-atoms": "^1.1.1",
+        "get-intrinsic": "^1.3.0",
+        "is-string": "^1.1.1",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlast": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlast/-/array.prototype.findlast-1.2.5.tgz",
+      "integrity": "sha512-CVvd6FHg1Z3POpBLxO6E6zr+rSKEQ9L6rZHAaY7lLfhKsWYUBBOuMs0e9o24oopj6H+geRCX0YJ+TJLBK2eHyQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.findlastindex": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/array.prototype.findlastindex/-/array.prototype.findlastindex-1.2.6.tgz",
+      "integrity": "sha512-F/TKATkzseUExPlfvmwQKGITM3DGTK+vkAsCZoDc5daVygbJBnjEUCbgkAvVFsgfXfX4YIqZ/27G3k3tdXrTxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-shim-unscopables": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flat": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.3.3.tgz",
+      "integrity": "sha512-rwG/ja1neyLqCuGZ5YYrznA62D4mZXg0i1cIskIUKSiqF3Cje9/wXAls9B9s1Wa2fomMsIv8czB8jZcPmxCXFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.flatmap": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.3.3.tgz",
+      "integrity": "sha512-Y7Wt51eKJSyi80hFrJCePGGNo5ktJCslFuboqJsbf57CCPcm5zztluPlc4/aD8sWsKvlwatezpV4U1efk8kpjg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/array.prototype.tosorted": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.tosorted/-/array.prototype.tosorted-1.1.4.tgz",
+      "integrity": "sha512-p6Fx8B7b7ZhL/gmUsAy0D15WhvDccw3mnGNbZpi3pmeJdxtWsj2jEaI4Y6oo3XiHfzuSgPwKc04MYt6KgvC/wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3",
+        "es-errors": "^1.3.0",
+        "es-shim-unscopables": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/arraybuffer.prototype.slice": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/arraybuffer.prototype.slice/-/arraybuffer.prototype.slice-1.0.4.tgz",
+      "integrity": "sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.1",
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.5",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "is-array-buffer": "^3.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ast-types-flow": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
+      "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/async-function": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
+      "integrity": "sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/axobject-query": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
+      "integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/damerau-levenshtein": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
+      "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/data-view-buffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
+      "integrity": "sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/data-view-byte-length": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/data-view-byte-length/-/data-view-byte-length-1.0.2.tgz",
+      "integrity": "sha512-tuhGbE6CfTM9+5ANGf+oQb72Ky/0+s3xKUpHvShfiz2RxMFgFPjsXuRLBVMtvMs15awe45SRb83D6wH4ew6wlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/inspect-js"
+      }
+    },
+    "node_modules/data-view-byte-offset": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/data-view-byte-offset/-/data-view-byte-offset-1.0.1.tgz",
+      "integrity": "sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-data-view": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/doctrine": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+      "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.5",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.5.tgz",
+      "integrity": "sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/es-abstract": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.2.tgz",
+      "integrity": "sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-buffer-byte-length": "^1.0.2",
+        "arraybuffer.prototype.slice": "^1.0.4",
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "data-view-buffer": "^1.0.2",
+        "data-view-byte-length": "^1.0.2",
+        "data-view-byte-offset": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "es-set-tostringtag": "^2.1.0",
+        "es-to-primitive": "^1.3.0",
+        "function.prototype.name": "^1.1.8",
+        "get-intrinsic": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "get-symbol-description": "^1.1.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "internal-slot": "^1.1.0",
+        "is-array-buffer": "^3.0.5",
+        "is-callable": "^1.2.7",
+        "is-data-view": "^1.0.2",
+        "is-negative-zero": "^2.0.3",
+        "is-regex": "^1.2.1",
+        "is-set": "^2.0.3",
+        "is-shared-array-buffer": "^1.0.4",
+        "is-string": "^1.1.1",
+        "is-typed-array": "^1.1.15",
+        "is-weakref": "^1.1.1",
+        "math-intrinsics": "^1.1.0",
+        "object-inspect": "^1.13.4",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.7",
+        "own-keys": "^1.0.1",
+        "regexp.prototype.flags": "^1.5.4",
+        "safe-array-concat": "^1.1.3",
+        "safe-push-apply": "^1.0.0",
+        "safe-regex-test": "^1.1.0",
+        "set-proto": "^1.0.0",
+        "stop-iteration-iterator": "^1.1.0",
+        "string.prototype.trim": "^1.2.10",
+        "string.prototype.trimend": "^1.0.9",
+        "string.prototype.trimstart": "^1.0.8",
+        "typed-array-buffer": "^1.0.3",
+        "typed-array-byte-length": "^1.0.3",
+        "typed-array-byte-offset": "^1.0.4",
+        "typed-array-length": "^1.0.7",
+        "unbox-primitive": "^1.1.0",
+        "which-typed-array": "^1.1.19"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-abstract-get": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/es-abstract-get/-/es-abstract-get-1.0.0.tgz",
+      "integrity": "sha512-6PMWXpdhshVvFp+FoWYs1EvG1Nj0tvk0dZM+XcK0xMEM1czRVcP6ohqPWHy6qPagSpC8j4+p89WXlT+xXJs/fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.2",
+        "is-callable": "^1.2.7",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-iterator-helpers": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.4.0.tgz",
+      "integrity": "sha512-c/A0P0oxkACDc+cKWw8evLXK83oBKgn0qPOqCYT4x9uolpCIJAcYvJC9QYKNDRPsTeGyCrQ326jrvgZWdCdK5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-errors": "^1.3.0",
+        "es-set-tostringtag": "^2.1.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.3.0",
+        "globalthis": "^1.0.4",
+        "gopd": "^1.2.0",
+        "has-property-descriptors": "^1.0.2",
+        "has-proto": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "iterator.prototype": "^1.1.5",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-shim-unscopables": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es-shim-unscopables/-/es-shim-unscopables-1.1.0.tgz",
+      "integrity": "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-to-primitive": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.3.4.tgz",
+      "integrity": "sha512-yPDz7wqpg1/mmHLmS3tcfTfbw5f1eryXvyghYBffGdERwe+mV7ZcWzTR8LR17Kvqt3qfPurjlonmnq3MKXIOXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-abstract-get": "^1.0.0",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "is-callable": "^1.2.7",
+        "is-date-object": "^1.1.0",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "9.39.5",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
+      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.8.0",
+        "@eslint-community/regexpp": "^4.12.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.6",
+        "@eslint/js": "9.39.5",
+        "@eslint/plugin-kit": "^0.4.1",
+        "@humanfs/node": "^0.16.6",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@humanwhocodes/retry": "^0.4.2",
+        "@types/estree": "^1.0.6",
+        "ajv": "^6.14.0",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.6",
+        "debug": "^4.3.2",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
+        "esquery": "^1.5.0",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^8.0.0",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.5",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "jiti": "*"
+      },
+      "peerDependenciesMeta": {
+        "jiti": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.5.22.tgz",
+      "integrity": "sha512-HhZsB3dvBsYwQpnymZm/Ps9NVaSYiSzDSXkR02CjyOcQutCuea3cF7NxE8i8Drs2+Dgw95WUzK2CMBIHd5YbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@next/eslint-plugin-next": "15.5.22",
+        "@rushstack/eslint-patch": "^1.10.3",
+        "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "eslint-import-resolver-node": "^0.3.6",
+        "eslint-import-resolver-typescript": "^3.5.2",
+        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-jsx-a11y": "^6.10.0",
+        "eslint-plugin-react": "^7.37.0",
+        "eslint-plugin-react-hooks": "^5.0.0"
+      },
+      "peerDependencies": {
+        "eslint": "^7.23.0 || ^8.0.0 || ^9.0.0",
+        "typescript": ">=3.3.1"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.10.tgz",
+      "integrity": "sha512-tRrKqFyCaKict5hOd244sL6EQFNycnMQnBe+j8uqGNXYzsImGbGUU4ibtoaBmv5FLwJwcFJNeg1GeVjQfbMrDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.16.1",
+        "resolve": "^2.0.0-next.6"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.10.1.tgz",
+      "integrity": "sha512-A1rHYb06zjMGAxdLSkN2fXPBwuSaQ0iO5M/hdyS0Ajj1VBaRp0sPD3dn1FhME3c/JluGFbwSxyCfqdSbtQLAHQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@nolyfill/is-core-module": "1.0.39",
+        "debug": "^4.4.0",
+        "get-tsconfig": "^4.10.0",
+        "is-bun-module": "^2.0.0",
+        "stable-hash": "^0.0.5",
+        "tinyglobby": "^0.2.13",
+        "unrs-resolver": "^1.6.2"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.14.0.tgz",
+      "integrity": "sha512-W2WCRZ9Dqntd+2u8jJcVMV2PKulc6RdLgUUoh/yQr3uB6lo/ZOeGx11sv60/8S4QFFKNslAlWhr9u0Ef7ZW6Ig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-module-utils/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import": {
+      "version": "2.32.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
+      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rtsao/scc": "^1.1.0",
+        "array-includes": "^3.1.9",
+        "array.prototype.findlastindex": "^1.2.6",
+        "array.prototype.flat": "^1.3.3",
+        "array.prototype.flatmap": "^1.3.3",
+        "debug": "^3.2.7",
+        "doctrine": "^2.1.0",
+        "eslint-import-resolver-node": "^0.3.9",
+        "eslint-module-utils": "^2.12.1",
+        "hasown": "^2.0.2",
+        "is-core-module": "^2.16.1",
+        "is-glob": "^4.0.3",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "object.groupby": "^1.0.3",
+        "object.values": "^1.2.1",
+        "semver": "^6.3.1",
+        "string.prototype.trimend": "^1.0.9",
+        "tsconfig-paths": "^3.15.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-import/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-plugin-jsx-a11y": {
+      "version": "6.10.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.2.tgz",
+      "integrity": "sha512-scB3nz4WmG75pV8+3eRUQOHZlNSUhFNq37xnpgRkCCELU3XMvXAxLk1eqWWyE22Ki4Q01Fnsw9BA3cJHDPgn2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aria-query": "^5.3.2",
+        "array-includes": "^3.1.8",
+        "array.prototype.flatmap": "^1.3.2",
+        "ast-types-flow": "^0.0.8",
+        "axe-core": "^4.10.0",
+        "axobject-query": "^4.1.0",
+        "damerau-levenshtein": "^1.0.8",
+        "emoji-regex": "^9.2.2",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^3.3.5",
+        "language-tags": "^1.0.9",
+        "minimatch": "^3.1.2",
+        "object.fromentries": "^2.0.8",
+        "safe-regex-test": "^1.0.3",
+        "string.prototype.includes": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
+      }
+    },
+    "node_modules/eslint-plugin-react": {
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.8",
+        "array.prototype.findlast": "^1.2.5",
+        "array.prototype.flatmap": "^1.3.3",
+        "array.prototype.tosorted": "^1.1.4",
+        "doctrine": "^2.1.0",
+        "es-iterator-helpers": "^1.2.1",
+        "estraverse": "^5.3.0",
+        "hasown": "^2.0.2",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
+        "minimatch": "^3.1.2",
+        "object.entries": "^1.1.9",
+        "object.fromentries": "^2.0.8",
+        "object.values": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "resolve": "^2.0.0-next.5",
+        "semver": "^6.3.1",
+        "string.prototype.matchall": "^4.0.12",
+        "string.prototype.repeat": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
+      }
+    },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-react/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/espree": {
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
+      "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+      "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flat-cache": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+      "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.prototype.name": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.2.0.tgz",
+      "integrity": "sha512-jObKIik1P2QjPHP5nz5BaOtUlfgS0fWo8IUByNXkM+o+02sJOi94em77GwJKQSJ3gfPHdgzLNrHc1uokV4P/ew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2",
+        "hasown": "^2.0.4",
+        "is-callable": "^1.2.7",
+        "is-document.all": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/functions-have-names": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/functions-have-names/-/functions-have-names-1.2.3.tgz",
+      "integrity": "sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-symbol-description": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
+      "integrity": "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-bigints": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
+      "integrity": "sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.2.0.tgz",
+      "integrity": "sha512-KIL7eQPfHQRC8+XluaIw7BHUwwqL19bQn4hzNgdr+1wXoU0KKj6rufu47lhY7KbJR2C6T6+PfyN0Ea7wkSS+qQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/internal-slot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
+      "integrity": "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "hasown": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
+      "integrity": "sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-async-function": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-async-function/-/is-async-function-2.1.1.tgz",
+      "integrity": "sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-function": "^1.0.0",
+        "call-bound": "^1.0.3",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-bigint/-/is-bigint-1.1.0.tgz",
+      "integrity": "sha512-n4ZT37wG78iz03xPRKJrHTdZbe3IicyucEtdRsV5yglwc3GyUfbAfpSeD0FJ41NbUNSt5wbhqfp1fS+BgnvDFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-bigints": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-boolean-object": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.2.2.tgz",
+      "integrity": "sha512-wa56o2/ElJMYqjCjGkXri7it5FbebW5usLw/nPmCMs5DeZ7eziSYZhSmPRn0txqeW4LnAmQQU7FgqLpsEFKM4A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hasown": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-data-view": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-data-view/-/is-data-view-1.0.2.tgz",
+      "integrity": "sha512-RKtWF8pGmS87i2D6gqQu/l7EYRlVdfzemCJN/P3UOs//x1QE7mfhvzHIApBTRf7axvT6DMGwSwBXYCT0nfB9xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "get-intrinsic": "^1.2.6",
+        "is-typed-array": "^1.1.13"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-date-object": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.1.0.tgz",
+      "integrity": "sha512-PwwhEakHVKTdRNVOw+/Gyh0+MzlCl4R6qKvkhuvLtPMggI1WAHt9sOwZxQLSGpUaDnrdyDsomoRgNnCfKNSXXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-document.all": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
+      "integrity": "sha512-+XSoyS05OdBbhFuELhgTCpFNHkpBOJqtsZfUFFpe5QTw+9Sjbh8zitxhQkYAo6wV7e1Vb8cAPvpCk9jGam/82g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-finalizationregistry": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-finalizationregistry/-/is-finalizationregistry-1.1.1.tgz",
+      "integrity": "sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-map": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.3.tgz",
+      "integrity": "sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-negative-zero": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.3.tgz",
+      "integrity": "sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-number-object": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.1.1.tgz",
+      "integrity": "sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-set": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.3.tgz",
+      "integrity": "sha512-iPAjerrse27/ygGLxw+EBR9agv9Y6uLeYVJMu+QNCoouJ1/1ri0mGrcWpfCqFZuzzx3WjtwxG098X+n4OuRkPg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-shared-array-buffer": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.4.tgz",
+      "integrity": "sha512-ISWac8drv4ZGfwKl5slpHG9OwPNty4jOWPRIhBpxOoD+hqITiwuipOQ2bNthAzwA3B4fIjO4Nln74N0S9byq8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-string": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.1.1.tgz",
+      "integrity": "sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-symbol": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.1.1.tgz",
+      "integrity": "sha512-9gGx6GTtCQM73BgmHQXfDmLtfjjTUDSyoxTCbp5WtoixAhfgsDirWIcVQ/IHpvI5Vgd5i/J5F7B9cN/WlVbC/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakmap": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
+      "integrity": "sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakref": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/is-weakref/-/is-weakref-1.1.1.tgz",
+      "integrity": "sha512-6i9mGWSlqzNMEqpCp93KwRS1uUOodk2OJ6b+sq7ZPDSy2WuI5NFIxp/254TytR8ftefexkWn5xNiHUNpPOfSew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-weakset": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-weakset/-/is-weakset-2.0.4.tgz",
+      "integrity": "sha512-mfcwb6IzQyOKTs84CQMrOwW4gQcaTOAWJ0zzJCl2WSPDrWk/OzDaImWFH3djXhb24g4eudZfLRozAvPGw4d9hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/iterator.prototype": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
+      "integrity": "sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "get-proto": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
+      }
+    },
+    "node_modules/jsx-ast-utils": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
+      "integrity": "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-includes": "^3.1.6",
+        "array.prototype.flat": "^1.3.1",
+        "object.assign": "^4.1.4",
+        "object.values": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/language-subtag-registry": {
+      "version": "0.3.23",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.23.tgz",
+      "integrity": "sha512-0K65Lea881pHotoGEa5gDlMxt3pctLi2RplBb7Ezh4rRdLEOtgi7n4EwK9lamnUCkKBqaeKRVebTq6BAxSkpXQ==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/language-tags": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/language-tags/-/language-tags-1.0.9.tgz",
+      "integrity": "sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "language-subtag-registry": "^0.3.20"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.4.tgz",
+      "integrity": "sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/next": {
+      "version": "15.5.22",
+      "resolved": "https://registry.npmjs.org/next/-/next-15.5.22.tgz",
+      "integrity": "sha512-mrtal1sRxO4YrlDS98sDuIvGZivKbFix8w7oAL9ZynfOgc3cADQOQgvwtMooc18Qr8bKzvQAcHwHZ0mbJ7zcfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "15.5.22",
+        "@swc/helpers": "0.5.15",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^19.8.0 || >= 20.0.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "15.5.22",
+        "@next/swc-darwin-x64": "15.5.22",
+        "@next/swc-linux-arm64-gnu": "15.5.22",
+        "@next/swc-linux-arm64-musl": "15.5.22",
+        "@next/swc-linux-x64-gnu": "15.5.22",
+        "@next/swc-linux-x64-musl": "15.5.22",
+        "@next/swc-win32-arm64-msvc": "15.5.22",
+        "@next/swc-win32-x64-msvc": "15.5.22",
+        "sharp": "^0.34.3"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-exports-info": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/node-exports-info/-/node-exports-info-1.6.2.tgz",
+      "integrity": "sha512-kXs9Go0cah0qHVV2v389IXQLdLCeE1xfFtjOAF+iobu0OIoG1pje8At2vMHyaPMiPMnG/LWP50twML21eMcAag==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array.prototype.flatmap": "^1.3.3",
+        "es-errors": "^1.3.0",
+        "object.entries": "^1.1.9",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/node-exports-info/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.assign": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.7.tgz",
+      "integrity": "sha512-nK28WOo+QIjBkDduTINE4JkF/UJJKyf2EJxvJKfblDpyg0Q+pkOHNTL0Qwy6NP6FhE/EnzV73BxxqcJaXY9anw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0",
+        "has-symbols": "^1.1.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.entries": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.fromentries": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.8.tgz",
+      "integrity": "sha512-k6E21FzySsSK5a21KRADBd/NGneRegFO5pLHfdQLpRDETUNJueLXs3WCzyQ3tFRDYgbq3KHGXfTbi2bs8WQ6rQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object.groupby": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
+      "integrity": "sha512-+Lhy3TQTuzXI5hevh8sBGqbmurHbbIjAi0Z4S63nthVLmLxfbj4T54a4CfZrXIrt9iP4mVAPYMo/v99taj3wjQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/object.values": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.2.1.tgz",
+      "integrity": "sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/own-keys": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+      "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "object-keys": "^1.1.1",
+        "safe-push-apply": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.16",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/reflect.getprototypeof": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.10.tgz",
+      "integrity": "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.9",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.7",
+        "get-proto": "^1.0.1",
+        "which-builtin-type": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/regexp.prototype.flags": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
+      "integrity": "sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "define-properties": "^1.2.1",
+        "es-errors": "^1.3.0",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "set-function-name": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve": {
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.2",
+        "node-exports-info": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safe-array-concat": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.4.tgz",
+      "integrity": "sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
+        "has-symbols": "^1.1.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-push-apply": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/safe-push-apply/-/safe-push-apply-1.0.0.tgz",
+      "integrity": "sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "isarray": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-function-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/set-function-name/-/set-function-name-2.0.2.tgz",
+      "integrity": "sha512-7PGFlmtwsEADb0WYyvCMa1t+yke6daIG4Wirafur5kcf+MhUnPms1UeR0CKQdTZD81yESwMHbtn+TR+dMviakQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "functions-have-names": "^1.2.3",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/set-proto": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/set-proto/-/set-proto-1.0.0.tgz",
+      "integrity": "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stable-hash": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
+      "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stop-iteration-iterator": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
+      "integrity": "sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "internal-slot": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.includes": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.includes/-/string.prototype.includes-2.0.1.tgz",
+      "integrity": "sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/string.prototype.matchall": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
+      "integrity": "sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.23.6",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "get-intrinsic": "^1.2.6",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "internal-slot": "^1.1.0",
+        "regexp.prototype.flags": "^1.5.3",
+        "set-function-name": "^2.0.2",
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.repeat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-1.0.0.tgz",
+      "integrity": "sha512-0u/TldDbKD8bFCQ/4f5+mNRrXwZ8hg2w7ZR8wa16e8z9XpePWl3eGEcUD0OXpEH/VJH/2G3gjUtR3ZOiBe2S/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "node_modules/string.prototype.trim": {
+      "version": "1.2.11",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.11.tgz",
+      "integrity": "sha512-PwvK7BU+CMTJGYQCTZb5RWXIML92lftJLhQz1tBzgKiqGxJaMlBAa48POXaNAC2s4y8jr3EFqrkF9+44neS46w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-data-property": "^1.1.4",
+        "define-properties": "^1.2.1",
+        "es-abstract": "^1.24.2",
+        "es-object-atoms": "^1.1.2",
+        "has-property-descriptors": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimend": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.10.tgz",
+      "integrity": "sha512-2+3aDAOmPTmuFwjDnmJG2ctEkQKVki7vOSqaxkv42Mowj1V6PnvuwFCRrR5lChUux1TBskPjfkeTOhqczDMxTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/string.prototype.trimstart": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.8.tgz",
+      "integrity": "sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.7",
+        "define-properties": "^1.2.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/strip-bom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+      "integrity": "sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.6.tgz",
+      "integrity": "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz",
+      "integrity": "sha512-2Ac2RgzDe/cn48GvOe3M+o82pEFewD3UPbyoUHHdKasHwJKjds4fLXWf/Ux5kATBKN20oaFGu+jbElp1pos0mg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/typed-array-byte-length": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-length/-/typed-array-byte-length-1.0.3.tgz",
+      "integrity": "sha512-BaXgOuIxz8n8pIq3e7Atg/7s+DpiYrxn4vdot3w9KbnBhcRQq6o3xemQdIfynqSeXeDrF32x+WvfzmOjPiY9lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-byte-offset": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-byte-offset/-/typed-array-byte-offset-1.0.4.tgz",
+      "integrity": "sha512-bTlAFB/FBYMcuX81gbL4OcpH5PmlFHqlCCpAl8AlEzMz5k53oNDvN8p1PNOWLEmI2x4orp3raOFB51tv9X+MFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "for-each": "^0.3.3",
+        "gopd": "^1.2.0",
+        "has-proto": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "reflect.getprototypeof": "^1.0.9"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typed-array-length": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.8.tgz",
+      "integrity": "sha512-phPGCwqr2+Qo0fwniCE8e4pKnGu/yFb5nD5Y8bf0EEeiI5GklnACYA9GFy/DrAeRrKHXvHn+1SUsOWgJp6RO+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.9",
+        "for-each": "^0.3.5",
+        "gopd": "^1.2.0",
+        "is-typed-array": "^1.1.15",
+        "possible-typed-array-names": "^1.1.0",
+        "reflect.getprototypeof": "^1.0.10"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/unbox-primitive": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
+      "integrity": "sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "has-bigints": "^1.0.2",
+        "has-symbols": "^1.1.0",
+        "which-boxed-primitive": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.12.2.tgz",
+      "integrity": "sha512-dmlRxBJJayXjqTwC+JtF1HhJmgf3ftQ3YejFcZrf4+KKtJv0qDsK1pjqaaVjG7wJ5NJ6UVP1OqRMQ71Z4C3rxQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.4"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.12.2",
+        "@unrs/resolver-binding-android-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-arm64": "1.12.2",
+        "@unrs/resolver-binding-darwin-x64": "1.12.2",
+        "@unrs/resolver-binding-freebsd-x64": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-loong64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.12.2",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.12.2",
+        "@unrs/resolver-binding-linux-x64-musl": "1.12.2",
+        "@unrs/resolver-binding-openharmony-arm64": "1.12.2",
+        "@unrs/resolver-binding-wasm32-wasi": "1.12.2",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.12.2",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/which-boxed-primitive": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/which-boxed-primitive/-/which-boxed-primitive-1.1.1.tgz",
+      "integrity": "sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-bigint": "^1.1.0",
+        "is-boolean-object": "^1.2.1",
+        "is-number-object": "^1.1.1",
+        "is-string": "^1.1.1",
+        "is-symbol": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-builtin-type": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/which-builtin-type/-/which-builtin-type-1.2.1.tgz",
+      "integrity": "sha512-6iBczoX+kDQ7a3+YJBnh3T+KZRxM/iYNPXicqk66/Qfm1b93iu+yOImkg0zHbj5LNOcNv1TEADiZ0xa34B4q6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "function.prototype.name": "^1.1.6",
+        "has-tostringtag": "^1.0.2",
+        "is-async-function": "^2.0.0",
+        "is-date-object": "^1.1.0",
+        "is-finalizationregistry": "^1.1.0",
+        "is-generator-function": "^1.0.10",
+        "is-regex": "^1.2.1",
+        "is-weakref": "^1.0.2",
+        "isarray": "^2.0.5",
+        "which-boxed-primitive": "^1.1.0",
+        "which-collection": "^1.0.2",
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-collection": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
+      "integrity": "sha512-K4jVyjnBdgvc86Y6BkaLZEN933SwYOuBFkdmBu9ZfkcAbdVbpITnDmjvZ/aQjRXQrv5EPkTnD1s39GiiqbngCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-map": "^2.0.3",
+        "is-set": "^2.0.3",
+        "is-weakmap": "^2.0.2",
+        "is-weakset": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "formava-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "eslint"
+  },
+  "dependencies": {
+    "next": "^15.1.6",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.2.0",
+    "@tailwindcss/postcss": "^4.0.0",
+    "@types/node": "^20.17.16",
+    "@types/react": "^19.0.8",
+    "@types/react-dom": "^19.0.3",
+    "eslint": "^9.19.0",
+    "eslint-config-next": "^15.1.6",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^5.7.3"
+  }
+}

--- a/frontend/src/app/api/health/route.ts
+++ b/frontend/src/app/api/health/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+
+import { apiClient } from '@/lib/api/client';
+
+/**
+ * BFF health route. Fetches FastAPI server-side over loopback and relays the
+ * result, proving TLS -> nginx -> Next.js -> FastAPI -> Postgres end to end.
+ */
+export async function GET() {
+  const result = await apiClient.health();
+
+  if (!result.success || !result.data) {
+    return NextResponse.json(
+      { error: result.error ?? 'health check failed' },
+      { status: 503 }
+    );
+  }
+
+  return NextResponse.json(result.data, { status: 200 });
+}

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -1,0 +1,79 @@
+import type { RegisterForm, User } from '@/types';
+
+export interface ApiResponse<T> {
+  success: boolean;
+  data?: T;
+  error?: string;
+}
+
+export interface HealthPayload {
+  db: string;
+  pgvector: string;
+}
+
+/**
+ * Base URL for the FastAPI backend.
+ *
+ * Server-side only. The browser never calls FastAPI directly under the BFF
+ * pattern -- it calls Next.js route handlers, which call FastAPI.
+ *
+ * Deliberately has no default: the "No silent fallbacks" global constraint
+ * applies to configuration as well as to data access. systemd supplies this
+ * via EnvironmentFile; local development sets it explicitly.
+ *
+ * Resolved lazily rather than at module load. `next build` imports this module
+ * for static analysis, and CI builds without runtime configuration -- a
+ * top-level throw would break the build rather than the request. Throwing on
+ * first use still fails loudly: the route handler turns it into a 503, which
+ * the constraint permits.
+ */
+function getApiBaseUrl(): string {
+  const url = process.env.FORMAVA_API_URL;
+  if (!url) {
+    throw new Error('FORMAVA_API_URL is not set; refusing to serve');
+  }
+  return url;
+}
+
+class ApiClient {
+  async health(): Promise<ApiResponse<HealthPayload>> {
+    try {
+      const res = await fetch(`${getApiBaseUrl()}/health`, {
+        cache: 'no-store',
+      });
+
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { detail?: string };
+        return { success: false, error: body.detail ?? `HTTP ${res.status}` };
+      }
+
+      return { success: true, data: (await res.json()) as HealthPayload };
+    } catch (err) {
+      return {
+        success: false,
+        error: err instanceof Error ? err.message : 'Unknown error',
+      };
+    }
+  }
+
+  // ---- Auth: implemented in Spec 4 (REST API + Next.js BFF) ----
+  // These throw rather than returning a fake success so that any premature
+  // use fails loudly. Signatures match the existing calls in AuthContext.
+
+  async login(
+    _username: string,
+    _password: string
+  ): Promise<ApiResponse<{ user: User }>> {
+    throw new Error('apiClient.login is not implemented until Spec 4');
+  }
+
+  async register(_userData: RegisterForm): Promise<ApiResponse<{ user: User }>> {
+    throw new Error('apiClient.register is not implemented until Spec 4');
+  }
+
+  async logout(): Promise<void> {
+    throw new Error('apiClient.logout is not implemented until Spec 4');
+  }
+}
+
+export const apiClient = new ApiClient();

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -110,7 +110,7 @@ export interface SyncStatus {
 export interface ApiError {
   message: string;
   code?: string;
-  details?: any;
+  details?: unknown;
 }
 
 // Form types for UI components

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": { "@/*": ["./src/*"] }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,9 @@
+[pytest]
+# The repo is not an installed package, so `app` is only importable when the
+# repo root is on sys.path. `python -m pytest` adds the working directory
+# implicitly and a bare `pytest` does not, which meant the suite passed locally
+# and failed in CI on the same commit. Declare the path instead of depending on
+# how pytest happens to be invoked.
+pythonpath = .
+
+testpaths = tests

--- a/requirements-api-dev.txt
+++ b/requirements-api-dev.txt
@@ -1,0 +1,4 @@
+-r requirements-api.txt
+pytest==8.3.4
+httpx==0.28.1
+ruff==0.11.12

--- a/requirements-api.txt
+++ b/requirements-api.txt
@@ -1,0 +1,8 @@
+# Slim production dependencies for the Formava API slice (Spec 1).
+# Deliberately separate from requirements.txt (the Gradio monolith),
+# which is dismantled in Specs 2-4.
+fastapi==0.115.12
+uvicorn[standard]==0.34.2
+pydantic==2.11.5
+python-dotenv==1.1.0
+psycopg[binary]>=3.2,<4

--- a/scripts/deploy_vps.sh
+++ b/scripts/deploy_vps.sh
@@ -42,6 +42,19 @@ sync_files() {
     # itself) and won't start without it. Only the *source* node_modules
     # trees (repo root and frontend/, both rebuildable via npm install) are
     # meant to be skipped.
+    #
+    # '.env' alone only matches a path component named exactly that -- it
+    # misses .env.local, .env.production, .env.staging, etc., which is
+    # exactly the set of filenames this repo's root .gitignore anticipates
+    # for local secret overrides. The '.env.*' glob is deliberately broad
+    # (matches at any depth, since rsync excludes without a leading '/' are
+    # unanchored) so any such file on a developer's machine never leaves it;
+    # secrets live only in /etc/formava/formava.env on the host.
+    #
+    # requirements.txt (the Gradio monolith's deps, never installed on the
+    # host) is excluded so "no Gradio on the host" holds at the filesystem
+    # level, not just inside the venv. requirements-api.txt and
+    # requirements-api-dev.txt are unaffected -- the deploy needs the former.
     rsync -avz --delete \
         --exclude '.git' \
         --exclude '.venv' \
@@ -49,6 +62,7 @@ sync_files() {
         --exclude '/frontend/node_modules' \
         --exclude '__pycache__' \
         --exclude '.env' \
+        --exclude '.env.*' \
         --exclude '.next/cache' \
         --exclude 'app/pages' \
         --exclude 'app/routes.py' \
@@ -57,6 +71,7 @@ sync_files() {
         --exclude 'tests' \
         --exclude '*.log' \
         --exclude '.DS_Store' \
+        --exclude 'requirements.txt' \
         "$PROJECT_DIR/" "${VPS_USER}@${VPS_HOST}:${APP_PATH}/"
 }
 

--- a/scripts/deploy_vps.sh
+++ b/scripts/deploy_vps.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Deploy Formava to the VPS. Modelled on Clio's scripts/deploy.sh.
+#
+# Usage:
+#   ./scripts/deploy_vps.sh            # build + sync + install + restart
+#   ./scripts/deploy_vps.sh sync       # rsync only
+#   ./scripts/deploy_vps.sh restart    # restart both units
+#   ./scripts/deploy_vps.sh logs api   # follow logs (api|web)
+#   ./scripts/deploy_vps.sh status
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+
+VPS_HOST="${VPS_HOST:-144.202.88.7}"
+VPS_USER="${VPS_USER:-root}"
+APP_PATH="${APP_PATH:-/opt/formava}"
+
+SSH="ssh ${VPS_USER}@${VPS_HOST}"
+
+GREEN='\033[0;32m'; NC='\033[0m'
+log() { echo -e "${GREEN}[deploy]${NC} $1"; }
+
+build_frontend() {
+    log "Building Next.js standalone bundle locally..."
+    # Built here, not on the host: `next build` wants 1.5-2 GB and would
+    # needlessly contend with Clio.
+    (cd "$PROJECT_DIR/frontend" && npm ci && npm run build)
+}
+
+sync_files() {
+    log "Syncing to ${VPS_HOST}:${APP_PATH}..."
+    $SSH "mkdir -p ${APP_PATH}"
+
+    # Gradio is deliberately excluded -- it must never reach the VPS.
+    rsync -avz --delete \
+        --exclude '.git' \
+        --exclude '.venv' \
+        --exclude 'node_modules' \
+        --exclude '__pycache__' \
+        --exclude '.env' \
+        --exclude '.next/cache' \
+        --exclude 'app/pages' \
+        --exclude 'app/routes.py' \
+        --exclude 'app/theme.py' \
+        --exclude 'app/config/state.py' \
+        --exclude 'tests' \
+        --exclude '*.log' \
+        --exclude '.DS_Store' \
+        "$PROJECT_DIR/" "${VPS_USER}@${VPS_HOST}:${APP_PATH}/"
+}
+
+install_deps() {
+    log "Installing Python dependencies in the venv..."
+    $SSH "cd ${APP_PATH} && \
+        (test -d .venv || python3 -m venv .venv) && \
+        .venv/bin/pip install --upgrade pip -q && \
+        .venv/bin/pip install -r requirements-api.txt -q"
+}
+
+install_units() {
+    log "Installing systemd units..."
+    $SSH "cp ${APP_PATH}/scripts/vps/formava-api.service /etc/systemd/system/ && \
+          cp ${APP_PATH}/scripts/vps/formava-web.service /etc/systemd/system/ && \
+          systemctl daemon-reload && \
+          systemctl enable formava-api formava-web"
+}
+
+restart_services() {
+    log "Restarting services..."
+    $SSH "systemctl restart formava-api formava-web"
+    sleep 3
+    $SSH "systemctl is-active formava-api formava-web"
+}
+
+case "${1:-deploy}" in
+    deploy)  build_frontend; sync_files; install_deps; install_units; restart_services ;;
+    build)   build_frontend ;;
+    sync)    sync_files ;;
+    install) install_deps; install_units ;;
+    restart) restart_services ;;
+    logs)    $SSH "journalctl -u formava-${2:-api} -f --no-pager -n 50" ;;
+    status)  $SSH "systemctl status formava-api formava-web --no-pager" ;;
+    *)       echo "Usage: $0 {deploy|build|sync|install|restart|logs|status}"; exit 1 ;;
+esac
+
+log "Done."

--- a/scripts/deploy_vps.sh
+++ b/scripts/deploy_vps.sh
@@ -33,10 +33,20 @@ sync_files() {
     $SSH "mkdir -p ${APP_PATH}"
 
     # Gradio is deliberately excluded -- it must never reach the VPS.
+    #
+    # node_modules excludes are anchored (leading '/') rather than a bare
+    # 'node_modules' pattern: an unanchored pattern also matches
+    # frontend/.next/standalone/node_modules, which is the trimmed,
+    # production-only dependency set that `next build` traces into the
+    # standalone bundle -- server.js requires it (e.g. the `next` package
+    # itself) and won't start without it. Only the *source* node_modules
+    # trees (repo root and frontend/, both rebuildable via npm install) are
+    # meant to be skipped.
     rsync -avz --delete \
         --exclude '.git' \
         --exclude '.venv' \
-        --exclude 'node_modules' \
+        --exclude '/node_modules' \
+        --exclude '/frontend/node_modules' \
         --exclude '__pycache__' \
         --exclude '.env' \
         --exclude '.next/cache' \

--- a/scripts/vps/fail2ban-filter-clio-auth.conf
+++ b/scripts/vps/fail2ban-filter-clio-auth.conf
@@ -1,0 +1,10 @@
+# Match repeated 401s against Clio's capture routes in nginx's access log.
+# The stock nginx-http-auth filter only catches nginx's own auth_basic
+# failures in error.log, not 401s returned by an upstream app.
+#
+# Default combined log format:
+#   $remote_addr - $remote_user [$time_local] "$request" $status ...
+[Definition]
+failregex = ^<HOST> - \S+ \[[^\]]+\] "(?:GET|POST) /capture(?:/[^/"]+/fix)?(?:\?\S*)? HTTP/[\d.]+" 401
+ignoreregex =
+datepattern = \[%%d/%%b/%%Y:%%H:%%M:%%S %%z\]

--- a/scripts/vps/fail2ban-filter-clio-auth.conf
+++ b/scripts/vps/fail2ban-filter-clio-auth.conf
@@ -4,7 +4,15 @@
 #
 # Default combined log format:
 #   $remote_addr - $remote_user [$time_local] "$request" $status ...
+#
+# NOTE: fail2ban's date detector consumes whatever it matches as the
+# timestamp and strips it from the line before failregex runs. If the
+# datepattern includes the surrounding brackets, the brackets themselves
+# are stripped too -- so datepattern below deliberately omits them, and
+# failregex matches the now-empty `[]` left behind. Verified against
+# this host's fail2ban (v1.0.2) with fail2ban-regex; a version with
+# \[[^\]]+\] here matches nothing.
 [Definition]
-failregex = ^<HOST> - \S+ \[[^\]]+\] "(?:GET|POST) /capture(?:/[^/"]+/fix)?(?:\?\S*)? HTTP/[\d.]+" 401
+failregex = ^<HOST> - \S+ \[\] "(?:GET|POST) /capture(?:/[^/"]+/fix)?(?:\?\S*)? HTTP/[\d.]+" 401
 ignoreregex =
-datepattern = \[%%d/%%b/%%Y:%%H:%%M:%%S %%z\]
+datepattern = %%d/%%b/%%Y:%%H:%%M:%%S %%z

--- a/scripts/vps/fail2ban-nginx.local
+++ b/scripts/vps/fail2ban-nginx.local
@@ -17,6 +17,16 @@ bantime  = 86400
 
 # Brute-force protection for the capture bearer token. The legitimate client
 # is a human dictating, so repeated 401s are never normal traffic.
+#
+# ignoreip here is jail-specific (overrides, not extends, the global
+# DEFAULT), so it must repeat 127.0.0.1/8 ::1 alongside the host's own
+# public IP. The host's own address is included because manual token
+# verification (curl against the public domain/IP, as during the token
+# cutover) logs with $remote_addr == the host's own IP, not loopback --
+# nginx sees that as the real peer since the request round-trips over the
+# public interface. A short burst of such manual testing could otherwise
+# self-ban the server. Confirmed via nginx access.log: real 401s from
+# 144.202.88.7 already exist from prior verification runs.
 [clio-capture-auth]
 enabled  = true
 port     = http,https
@@ -25,3 +35,4 @@ logpath  = /var/log/nginx/access.log
 maxretry = 5
 findtime = 600
 bantime  = 86400
+ignoreip = 127.0.0.1/8 ::1 144.202.88.7

--- a/scripts/vps/fail2ban-nginx.local
+++ b/scripts/vps/fail2ban-nginx.local
@@ -1,0 +1,27 @@
+# nginx jails for Clio and Formava. Installed to /etc/fail2ban/jail.d/.
+[nginx-http-auth]
+enabled  = true
+port     = http,https
+logpath  = /var/log/nginx/error.log
+maxretry = 5
+findtime = 600
+bantime  = 3600
+
+[nginx-badbots]
+enabled  = true
+port     = http,https
+logpath  = /var/log/nginx/access.log
+maxretry = 2
+findtime = 600
+bantime  = 86400
+
+# Brute-force protection for the capture bearer token. The legitimate client
+# is a human dictating, so repeated 401s are never normal traffic.
+[clio-capture-auth]
+enabled  = true
+port     = http,https
+filter   = clio-capture-auth
+logpath  = /var/log/nginx/access.log
+maxretry = 5
+findtime = 600
+bantime  = 86400

--- a/scripts/vps/fail2ban-nginx.local
+++ b/scripts/vps/fail2ban-nginx.local
@@ -1,6 +1,14 @@
 # nginx jails for Clio and Formava. Installed to /etc/fail2ban/jail.d/.
+#
+# backend = auto is REQUIRED on this host. /etc/fail2ban/jail.d/defaults-debian.conf
+# sets `backend = systemd` for [DEFAULT], which silently overrides logpath: the jail
+# loads, reports active, and monitors nothing, because nginx logs to files and never
+# to the journal. Verify with `fail2ban-client get <jail> logpath` -- it must name the
+# file, not "No file is currently monitored". Do not fix this globally: the sshd jail
+# legitimately uses the systemd backend and works.
 [nginx-http-auth]
 enabled  = true
+backend  = auto
 port     = http,https
 logpath  = /var/log/nginx/error.log
 maxretry = 5
@@ -15,6 +23,7 @@ bantime  = 3600
 # path probes -- matching the Dahua/CGI enumeration traffic this jail targets.
 [nginx-badbots]
 enabled  = true
+backend  = auto
 port     = http,https
 filter   = nginx-botsearch
 logpath  = /var/log/nginx/access.log
@@ -36,6 +45,7 @@ bantime  = 86400
 # 144.202.88.7 already exist from prior verification runs.
 [clio-capture-auth]
 enabled  = true
+backend  = auto
 port     = http,https
 filter   = clio-capture-auth
 logpath  = /var/log/nginx/access.log

--- a/scripts/vps/fail2ban-nginx.local
+++ b/scripts/vps/fail2ban-nginx.local
@@ -7,9 +7,16 @@ maxretry = 5
 findtime = 600
 bantime  = 3600
 
+# On this host's fail2ban (v1.0.2) there is no filter.d/nginx-badbots.conf;
+# the shipped stock filter for bad-bot/CGI/enumeration probes against
+# access.log is named nginx-botsearch (confirmed via `ls /etc/fail2ban/filter.d/`
+# and a fail2ban ERROR log entry: "Unable to read the filter 'nginx-badbots'"
+# without this line). It covers cgi-bin, phpMyAdmin, WordPress, and webmail
+# path probes -- matching the Dahua/CGI enumeration traffic this jail targets.
 [nginx-badbots]
 enabled  = true
 port     = http,https
+filter   = nginx-botsearch
 logpath  = /var/log/nginx/access.log
 maxretry = 2
 findtime = 600

--- a/scripts/vps/formava-api.service
+++ b/scripts/vps/formava-api.service
@@ -1,0 +1,28 @@
+[Unit]
+Description=Formava API (FastAPI)
+After=network.target postgresql.service
+Requires=postgresql.service
+StartLimitBurst=5
+StartLimitIntervalSec=60
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/formava
+EnvironmentFile=/etc/formava/formava.env
+ExecStart=/opt/formava/.venv/bin/uvicorn app.health.api:create_app --factory \
+    --host 127.0.0.1 --port 8000
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=formava-api
+
+# Cap ~3x measured steady state. Combined with formava-web (512M) and
+# Postgres (320M) this stays well inside 3.8 GB, so a runaway here is killed
+# by the kernel before it can pressure clio.service into its
+# StartLimitBurst=5 permanent-failure state.
+MemoryMax=768M
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/vps/formava-backup.service
+++ b/scripts/vps/formava-backup.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Formava Postgres backup
+After=postgresql.service
+Requires=postgresql.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/formava/scripts/vps/pg_backup.sh
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=formava-backup

--- a/scripts/vps/formava-backup.timer
+++ b/scripts/vps/formava-backup.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Nightly Formava Postgres backup
+
+[Timer]
+OnCalendar=daily
+# Spread load off the hour, and survive missed windows after a reboot.
+RandomizedDelaySec=1800
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/scripts/vps/formava-web.service
+++ b/scripts/vps/formava-web.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=Formava Web (Next.js BFF)
+After=network.target formava-api.service
+StartLimitBurst=5
+StartLimitIntervalSec=60
+
+[Service]
+Type=simple
+User=root
+WorkingDirectory=/opt/formava/frontend/.next/standalone
+EnvironmentFile=/etc/formava/formava.env
+Environment=NODE_ENV=production
+Environment=PORT=3001
+Environment=HOSTNAME=127.0.0.1
+ExecStart=/usr/bin/node server.js
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=formava-web
+
+MemoryMax=512M
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/vps/nginx-clio.conf
+++ b/scripts/vps/nginx-clio.conf
@@ -1,0 +1,63 @@
+# Clio — allowlist vhost. Only paths with a known caller are published.
+# /status, /capture/bulk, /capture/fix, /capture/fix/recent stay closed.
+limit_req_zone $binary_remote_addr zone=capture:1m  rate=10r/m;
+limit_req_zone $binary_remote_addr zone=sessions:1m rate=60r/m;
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name clio.lantzbuilds.com;
+
+    client_max_body_size 64k;
+
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header Referrer-Policy "no-referrer" always;
+
+    # iOS Shortcut — new capture
+    location = /capture {
+        limit_except POST { deny all; }
+        limit_req zone=capture burst=5 nodelay;
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host            $host;
+        proxy_set_header X-Real-IP       $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # iOS Shortcut — correct an existing capture by id.
+    # Regex because an exact match cannot cover a path parameter. Anchored to
+    # exactly three segments so /capture/fix and /capture/fix/recent do NOT
+    # match and stay closed. nginx evaluates regex locations before plain
+    # prefix matches, so `location /` never sees this.
+    location ~ ^/capture/[^/]+/fix$ {
+        limit_except POST { deny all; }
+        limit_req zone=capture burst=5 nodelay;
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host            $host;
+        proxy_set_header X-Real-IP       $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    }
+
+    # CLI connection validation
+    location = /health {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+    }
+
+    # CLI session control. SSE settings are load-bearing: with nginx's
+    # default proxy_buffering the chat stream is buffered and typewriter
+    # rendering breaks, and the default 60s read timeout severs long turns.
+    location /api/sessions {
+        limit_req zone=sessions burst=20 nodelay;
+        proxy_pass http://127.0.0.1:3000;
+        proxy_http_version 1.1;
+        proxy_set_header Host            $host;
+        proxy_set_header X-Real-IP       $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Connection      '';
+        proxy_buffering off;
+        proxy_cache off;
+        proxy_read_timeout 120s;
+    }
+
+    location / { return 404; }
+}

--- a/scripts/vps/nginx-clio.conf
+++ b/scripts/vps/nginx-clio.conf
@@ -13,6 +13,12 @@ server {
     add_header X-Content-Type-Options "nosniff" always;
     add_header Referrer-Policy "no-referrer" always;
 
+    # Clio's own app (helmet) sends `includeSubDomains`, which is not wanted
+    # on this shared personal domain (other hosts live under lantzbuilds.com).
+    # Override rather than trust the upstream value.
+    proxy_hide_header Strict-Transport-Security;
+    add_header Strict-Transport-Security "max-age=31536000" always;
+
     # iOS Shortcut — new capture
     location = /capture {
         limit_except POST { deny all; }

--- a/scripts/vps/nginx-formava.conf
+++ b/scripts/vps/nginx-formava.conf
@@ -1,8 +1,10 @@
-# Formava — Next.js BFF. certbot injects the TLS listener and redirect.
+# Formava — Next.js BFF. certbot injects a TLS listener into this block
+# and into the www block below (both are requested via -d formava.io
+# -d www.formava.io, so both get the same certificate).
 server {
     listen 80;
     listen [::]:80;
-    server_name formava.io www.formava.io;
+    server_name formava.io;
 
     client_max_body_size 2m;
 
@@ -20,4 +22,19 @@ server {
         proxy_set_header Upgrade           $http_upgrade;
         proxy_set_header Connection        "upgrade";
     }
+}
+
+# www.formava.io is a distinct origin from the apex, not an alias of it:
+# Spec 4 sets session cookies on formava.io, and a cookie set on formava.io
+# is not sent to www.formava.io. So www must redirect to the apex rather
+# than serve the app on its own origin — keeping it a separate server
+# block (instead of adding www to server_name above) ensures certbot's
+# TLS listener and redirect land on this block as a 301-to-apex, not as
+# a second identity serving the app.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name www.formava.io;
+
+    return 301 https://formava.io$request_uri;
 }

--- a/scripts/vps/nginx-formava.conf
+++ b/scripts/vps/nginx-formava.conf
@@ -1,0 +1,23 @@
+# Formava — Next.js BFF. certbot injects the TLS listener and redirect.
+server {
+    listen 80;
+    listen [::]:80;
+    server_name formava.io www.formava.io;
+
+    client_max_body_size 2m;
+
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+
+    location / {
+        proxy_pass http://127.0.0.1:3001;
+        proxy_http_version 1.1;
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header Upgrade           $http_upgrade;
+        proxy_set_header Connection        "upgrade";
+    }
+}

--- a/scripts/vps/nginx-formava.conf
+++ b/scripts/vps/nginx-formava.conf
@@ -31,6 +31,14 @@ server {
 # block (instead of adding www to server_name above) ensures certbot's
 # TLS listener and redirect land on this block as a 301-to-apex, not as
 # a second identity serving the app.
+#
+# UNTESTED FROM SCRATCH: the live topology was produced by editing the
+# post-certbot config, not by running certbot against this file. When
+# certbot --nginx --redirect meets the www block below (which already has
+# its own `return 301`), it may add its own if-based redirect alongside,
+# leaving two overlapping mechanisms in one block. On a fresh host, run
+# certbot first, then verify `nginx -T` shows exactly one redirect
+# mechanism per block before trusting it.
 server {
     listen 80;
     listen [::]:80;

--- a/scripts/vps/pg_backup.sh
+++ b/scripts/vps/pg_backup.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Nightly pg_dump of the formava database with 7-day retention.
+set -euo pipefail
+
+BACKUP_DIR="/var/backups/formava"
+DB_NAME="formava"
+RETENTION_DAYS=7
+STAMP="$(date +%Y%m%d-%H%M%S)"
+TARGET="${BACKUP_DIR}/${DB_NAME}-${STAMP}.sql.gz"
+
+mkdir -p "${BACKUP_DIR}"
+chmod 0700 "${BACKUP_DIR}"
+
+sudo -u postgres pg_dump --no-owner "${DB_NAME}" | gzip > "${TARGET}"
+
+# Fail loudly on an empty or tiny dump rather than silently keeping garbage.
+if [ ! -s "${TARGET}" ] || [ "$(stat -c%s "${TARGET}")" -lt 100 ]; then
+    echo "ERROR: backup ${TARGET} is empty or truncated" >&2
+    exit 1
+fi
+
+find "${BACKUP_DIR}" -name "${DB_NAME}-*.sql.gz" \
+    -mtime "+${RETENTION_DAYS}" -delete
+
+echo "Backup complete: ${TARGET} ($(du -h "${TARGET}" | cut -f1))"

--- a/scripts/vps/provision_postgres.sh
+++ b/scripts/vps/provision_postgres.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Provision Postgres 16 + pgvector for Formava. Idempotent: safe to re-run.
+#
+# Usage: ./provision_postgres.sh <formava_db_password>
+set -euo pipefail
+
+DB_PASSWORD="${1:?Usage: $0 <formava_db_password>}"
+DB_NAME="formava"
+DB_USER="formava"
+PG_VERSION="16"
+PG_CONF="/etc/postgresql/${PG_VERSION}/main/postgresql.conf"
+
+log() { echo "[provision-postgres] $*"; }
+
+log "Installing packages from Ubuntu repositories..."
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -qq
+apt-get install -y --no-install-recommends \
+    "postgresql-${PG_VERSION}" \
+    "postgresql-${PG_VERSION}-pgvector"
+
+log "Ensuring role ${DB_USER} exists..."
+if ! sudo -u postgres psql -tAc \
+    "SELECT 1 FROM pg_roles WHERE rolname='${DB_USER}'" | grep -q 1; then
+    sudo -u postgres psql -c \
+        "CREATE ROLE ${DB_USER} LOGIN PASSWORD '${DB_PASSWORD}';"
+else
+    log "Role exists; syncing password."
+    sudo -u postgres psql -c \
+        "ALTER ROLE ${DB_USER} WITH LOGIN PASSWORD '${DB_PASSWORD}';"
+fi
+
+log "Ensuring database ${DB_NAME} exists..."
+if ! sudo -u postgres psql -tAc \
+    "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" | grep -q 1; then
+    sudo -u postgres createdb -O "${DB_USER}" "${DB_NAME}"
+fi
+
+log "Enabling pgvector in ${DB_NAME}..."
+sudo -u postgres psql -d "${DB_NAME}" -c "CREATE EXTENSION IF NOT EXISTS vector;"
+
+log "Applying tuning for 2 vCPU / 3.8 GB..."
+# Values are fixed by the spec's memory budget. Appended in a marked block so
+# re-runs replace rather than accumulate.
+MARKER="# --- formava tuning (managed) ---"
+if grep -qF "${MARKER}" "${PG_CONF}"; then
+    sed -i "/${MARKER}/,\$d" "${PG_CONF}"
+fi
+cat >> "${PG_CONF}" <<EOF
+${MARKER}
+listen_addresses = 'localhost'
+shared_buffers = 256MB
+effective_cache_size = 1GB
+max_connections = 50
+password_encryption = scram-sha-256
+EOF
+
+log "Restarting Postgres..."
+systemctl restart postgresql
+systemctl enable postgresql
+
+log "Verifying..."
+sudo -u postgres psql -d "${DB_NAME}" -tAc \
+    "SELECT extversion FROM pg_extension WHERE extname='vector'"
+ss -tlnp | grep 5432 || true
+
+log "Done."

--- a/scripts/vps/provision_postgres.sh
+++ b/scripts/vps/provision_postgres.sh
@@ -1,10 +1,33 @@
 #!/usr/bin/env bash
 # Provision Postgres 16 + pgvector for Formava. Idempotent: safe to re-run.
 #
-# Usage: ./provision_postgres.sh <formava_db_password>
+# Usage:
+#   printf '%s' "$PASSWORD" | ./provision_postgres.sh
+#   ./provision_postgres.sh                 # interactive prompt (TTY)
 set -euo pipefail
 
-DB_PASSWORD="${1:?Usage: $0 <formava_db_password>}"
+# Read the password from stdin rather than argv: a positional argument is
+# visible in ps/proc for the lifetime of the process.
+#
+# `read` exits nonzero on EOF even when it did capture data -- e.g.
+# `printf '%s' "$PASSWORD" | ...` (no trailing newline, as shown in Usage
+# above) hits EOF right after the value. Under `set -e` that would abort
+# the script immediately after this line despite DB_PASSWORD being set
+# correctly, so failure here is tolerated and delegated to the explicit
+# emptiness check below.
+if [ -t 0 ]; then
+    printf 'Postgres password for role formava: ' >&2
+    read -rs DB_PASSWORD || true
+    printf '\n' >&2
+else
+    read -r DB_PASSWORD || true
+fi
+
+if [ "${#DB_PASSWORD}" -eq 0 ]; then
+    echo "ERROR: no password supplied on stdin" >&2
+    exit 1
+fi
+
 DB_NAME="formava"
 DB_USER="formava"
 PG_VERSION="16"
@@ -20,14 +43,19 @@ apt-get install -y --no-install-recommends \
     "postgresql-${PG_VERSION}-pgvector"
 
 log "Ensuring role ${DB_USER} exists..."
+# The password-bearing statements are piped to psql via stdin (heredoc)
+# rather than passed with -c, so the plaintext never appears in psql's argv
+# either.
 if ! sudo -u postgres psql -tAc \
     "SELECT 1 FROM pg_roles WHERE rolname='${DB_USER}'" | grep -q 1; then
-    sudo -u postgres psql -c \
-        "CREATE ROLE ${DB_USER} LOGIN PASSWORD '${DB_PASSWORD}';"
+    sudo -u postgres psql <<SQL
+CREATE ROLE ${DB_USER} LOGIN PASSWORD '${DB_PASSWORD}';
+SQL
 else
     log "Role exists; syncing password."
-    sudo -u postgres psql -c \
-        "ALTER ROLE ${DB_USER} WITH LOGIN PASSWORD '${DB_PASSWORD}';"
+    sudo -u postgres psql <<SQL
+ALTER ROLE ${DB_USER} WITH LOGIN PASSWORD '${DB_PASSWORD}';
+SQL
 fi
 
 log "Ensuring database ${DB_NAME} exists..."
@@ -42,17 +70,35 @@ sudo -u postgres psql -d "${DB_NAME}" -c "CREATE EXTENSION IF NOT EXISTS vector;
 log "Applying tuning for 2 vCPU / 3.8 GB..."
 # Values are fixed by the spec's memory budget. Appended in a marked block so
 # re-runs replace rather than accumulate.
-MARKER="# --- formava tuning (managed) ---"
-if grep -qF "${MARKER}" "${PG_CONF}"; then
-    sed -i "/${MARKER}/,\$d" "${PG_CONF}"
+OLD_MARKER="# --- formava tuning (managed) ---"
+BEGIN_MARKER="# --- formava tuning (managed) — do not edit between markers ---"
+END_MARKER="# --- end formava tuning ---"
+
+# One-time migration from the old unbounded-marker format (no end marker).
+# The old block is known to always be the final lines of the file -- it was
+# always appended last by this same script and this script never appended
+# anything after it -- so old-marker-to-EOF is safe *only* for this specific
+# legacy case. This is NOT the general deletion strategy below; it must
+# never be used once the bounded format (with END_MARKER) is in place.
+if grep -qF "${OLD_MARKER}" "${PG_CONF}" && ! grep -qF "${BEGIN_MARKER}" "${PG_CONF}"; then
+    sed -i "/${OLD_MARKER}/,\$d" "${PG_CONF}"
 fi
+
+# Delete only the managed block, never to end-of-file: anything an operator
+# appends below our block must survive a re-run. Neither marker contains a
+# '/', so the default sed delimiter is safe here.
+if grep -qF "${BEGIN_MARKER}" "${PG_CONF}"; then
+    sed -i "/${BEGIN_MARKER}/,/${END_MARKER}/d" "${PG_CONF}"
+fi
+
 cat >> "${PG_CONF}" <<EOF
-${MARKER}
+${BEGIN_MARKER}
 listen_addresses = 'localhost'
 shared_buffers = 256MB
 effective_cache_size = 1GB
 max_connections = 50
 password_encryption = scram-sha-256
+${END_MARKER}
 EOF
 
 log "Restarting Postgres..."

--- a/scripts/vps/provision_postgres.sh
+++ b/scripts/vps/provision_postgres.sh
@@ -15,12 +15,27 @@ set -euo pipefail
 # the script immediately after this line despite DB_PASSWORD being set
 # correctly, so failure here is tolerated and delegated to the explicit
 # emptiness check below.
+#
+# DB_PASSWORD is pre-initialized so that if fd 0 is fully closed (e.g.
+# `... <&-`, as opposed to merely empty/EOF), `read` fails before ever
+# assigning it and the `${#DB_PASSWORD}` check below still has a defined
+# variable to test under `set -u`, giving our own error message instead of
+# a raw "unbound variable" abort.
+#
+# `IFS=` is scoped to each `read` so bash does not field-split the input:
+# plain `read` strips leading/trailing whitespace, which would silently
+# truncate a password that has boundary spaces (e.g. pasted from a
+# generator or a manager) instead of erroring -- exactly the silent-wrong-
+# state failure mode this hardening exists to eliminate. Scoping it to the
+# `read` command itself (rather than `export IFS=` or setting it at top of
+# script) means it does not leak into any other command in this script.
+DB_PASSWORD=""
 if [ -t 0 ]; then
     printf 'Postgres password for role formava: ' >&2
-    read -rs DB_PASSWORD || true
+    IFS= read -rs DB_PASSWORD || true
     printf '\n' >&2
 else
-    read -r DB_PASSWORD || true
+    IFS= read -r DB_PASSWORD || true
 fi
 
 if [ "${#DB_PASSWORD}" -eq 0 ]; then

--- a/scripts/vps/verify.sh
+++ b/scripts/vps/verify.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# Assert every Spec 1 exit criterion. Safe to re-run. Exits non-zero on failure.
+#
+# Usage: ./scripts/vps/verify.sh
+#
+# Needs key-based root SSH to the VPS. Password auth is off, so sshpass and
+# friends will not work. Clio's two scoped tokens are read off the host into
+# this script's environment rather than passed in, so no secret reaches shell
+# history or the process table of another user.
+#
+# `set -e` is deliberately omitted: a failing check must not abort the run.
+# Every assertion should report, and the exit code is the roll-up.
+set -uo pipefail
+
+VPS="${VPS_HOST:-144.202.88.7}"
+SSH="ssh -o BatchMode=yes -o ConnectTimeout=10 root@${VPS}"
+CLIO="https://clio.lantzbuilds.com"
+FAIL=0
+
+pass() { echo "  ok    $1"; }
+fail() { echo "  FAIL  $1"; FAIL=1; }
+
+check() { # description, actual, expected
+    [ "$2" = "$3" ] && pass "$1 ($2)" || fail "$1 — got '$2', want '$3'"
+}
+
+code() { curl -s -o /dev/null -w '%{http_code}' --max-time 15 "$@"; }
+
+# nginx rate-limits /capture and /capture/<id>/fix to 10r/m with burst 5
+# (see nginx-clio.conf). This script spends the whole burst, so a re-run inside
+# the same minute would get 503s from nginx and report false failures. Back off
+# and retry instead: the bucket refills one slot every 6s.
+capture_code() {
+    local c i
+    for i in 1 2 3 4; do
+        c="$(code "$@")"
+        [ "$c" != "503" ] && { echo "$c"; return; }
+        sleep 7
+    done
+    echo "$c"
+}
+
+echo "== SSH =="
+if $SSH true 2>/dev/null; then
+    pass "key-based root SSH"
+else
+    echo "  FAIL  key-based root SSH — cannot continue"
+    exit 1
+fi
+
+# Read once, reuse. Never echoed.
+CAPTURE_TOKEN="$($SSH "grep '^CAPTURE_TOKEN=' /opt/clio/.env | cut -d= -f2-")"
+SESSION_TOKEN="$($SSH "grep '^SESSION_TOKEN=' /opt/clio/.env | cut -d= -f2-")"
+[ -n "$CAPTURE_TOKEN" ] && pass "CAPTURE_TOKEN present" || fail "CAPTURE_TOKEN present"
+[ -n "$SESSION_TOKEN" ] && pass "SESSION_TOKEN present" || fail "SESSION_TOKEN present"
+check "legacy CAPTURE_API_TOKEN removed" \
+  "$($SSH "grep -c '^CAPTURE_API_TOKEN=' /opt/clio/.env")" "0"
+
+echo
+echo "== Formava =="
+check "http->https redirect" "$(code http://formava.io)" "301"
+check "www->apex redirect"   "$(code http://www.formava.io)" "301"
+check "https serves app"     "$(code https://formava.io)" "200"
+
+HEALTH="$(curl -s --max-time 15 https://formava.io/api/health)"
+echo "$HEALTH" | grep -q '"db":"ok"' \
+  && pass "BFF health chain ($HEALTH)" || fail "BFF health chain — got '$HEALTH'"
+
+# This script proves Clio's auth works by deliberately provoking 401s — which is
+# exactly the signal the clio-capture-auth jail bans on (maxretry 5, findtime
+# 600s, bantime 24h). Left alone, one run bans the operator for a day, and the
+# "safe to re-run" guarantee is a lie.
+#
+# So bracket the Clio section: whitelist this machine in that one jail for the
+# duration, then remove it and clear any ban. The IP comes from the host's view
+# of our SSH connection, which is the same egress nginx logs, and needs no
+# external lookup service. The trap makes removal unconditional so an
+# interrupted run never leaves the jail weakened.
+MYIP="$($SSH 'echo $SSH_CLIENT' | cut -d' ' -f1)"
+
+f2b_unguard() {
+    [ -n "${MYIP:-}" ] || return 0
+    $SSH "fail2ban-client set clio-capture-auth delignoreip ${MYIP}; \
+          fail2ban-client set clio-capture-auth unbanip ${MYIP}" >/dev/null 2>&1 || true
+}
+
+if [ -n "$MYIP" ]; then
+    trap f2b_unguard EXIT INT TERM
+    $SSH "fail2ban-client set clio-capture-auth addignoreip ${MYIP}" >/dev/null 2>&1 \
+      && pass "fail2ban guard armed for ${MYIP}" \
+      || fail "fail2ban guard armed for ${MYIP}"
+else
+    fail "could not determine this machine's source IP — refusing to self-ban"
+    echo "SOME CHECKS FAILED"
+    exit 1
+fi
+
+echo
+echo "== Clio: closed paths =="
+# Served by `location / { return 404; }`, which carries no limit_req, so these
+# cost nothing against the capture bucket.
+for p in /status /capture/bulk /capture/fix /capture/fix/recent /v404/exec; do
+    check "closed: $p" \
+      "$(code -H "Authorization: Bearer ${CAPTURE_TOKEN}" "${CLIO}${p}")" "404"
+done
+
+echo
+echo "== Clio: published paths =="
+check "GET /health reachable" "$(code ${CLIO}/health)" "200"
+check "GET /capture rejected by limit_except" \
+  "$(capture_code -H "Authorization: Bearer ${CAPTURE_TOKEN}" ${CLIO}/capture)" "403"
+check "POST /capture without token" \
+  "$(capture_code -X POST -H 'Content-Type: application/json' \
+     --data '{"text":"x"}' ${CLIO}/capture)" "401"
+
+echo
+echo "== Clio: token scope isolation =="
+# The point of the Task 6 token split. Each token must be accepted on its own
+# surface and rejected on the other's.
+#
+# An empty JSON object is used rather than a real payload: it clears auth and
+# then fails validation with 400, which proves the token was accepted without
+# writing a capture into the vault on every run.
+check "capture token accepted on /capture" \
+  "$(capture_code -X POST -H "Authorization: Bearer ${CAPTURE_TOKEN}" \
+     -H 'Content-Type: application/json' --data '{}' ${CLIO}/capture)" "400"
+check "capture token accepted on /capture/<id>/fix" \
+  "$(capture_code -X POST -H "Authorization: Bearer ${CAPTURE_TOKEN}" \
+     -H 'Content-Type: application/json' --data '{}' \
+     ${CLIO}/capture/verify-probe/fix)" "400"
+check "capture token REJECTED on /api/sessions" \
+  "$(code -H "Authorization: Bearer ${CAPTURE_TOKEN}" \
+     ${CLIO}/api/sessions/verify-probe)" "401"
+
+# /api/sessions is published — the Clio CLI depends on it. Proven with a GET on
+# an id that does not exist: 404 means the token authenticated and the lookup
+# missed, so the session token is live without a session row being created.
+check "session token accepted on /api/sessions" \
+  "$(code -H "Authorization: Bearer ${SESSION_TOKEN}" \
+     ${CLIO}/api/sessions/verify-probe)" "404"
+check "session token REJECTED on /capture" \
+  "$(capture_code -X POST -H "Authorization: Bearer ${SESSION_TOKEN}" \
+     -H 'Content-Type: application/json' --data '{}' ${CLIO}/capture)" "401"
+check "/api/sessions requires a token" \
+  "$(code ${CLIO}/api/sessions/verify-probe)" "401"
+
+# Close the whitelist window as soon as the last 401-provoking check is done,
+# rather than leaving it open for the remaining minute of host checks. The trap
+# stays armed as a safety net; a second removal is a no-op.
+f2b_unguard
+pass "fail2ban guard released"
+
+echo
+echo "== Network =="
+# Tested from off-host on purpose. Clio still binds 0.0.0.0 (Clio-side finding
+# 3, a one-line listen() change), so ufw is the only thing closing this port. A
+# loopback test would pass and prove nothing.
+timeout 8 curl -s -o /dev/null "http://${VPS}:3000/capture" 2>/dev/null \
+  && fail "port 3000 blocked from off-host" \
+  || pass "port 3000 blocked from off-host"
+
+# Counting rule lines would read 6, not 3: ufw prints a v4 and a v6 rule for
+# each port. Compare the distinct port set instead, which also proves no extra
+# port (3000 included) is open.
+check "ufw open ports" \
+  "$($SSH "ufw status | grep -oE '^[0-9]+' | sort -un | tr '\n' ','")" \
+  "22,80,443,"
+check "formava binds loopback only" \
+  "$($SSH "ss -tln | grep -cE '0\.0\.0\.0:(3001|8000|5432)'")" "0"
+
+echo
+echo "== SSH hardening =="
+# The property, not the directive. The directive lives in a drop-in
+# (/etc/ssh/sshd_config.d/00-hardening.conf), not the main config, so grepping
+# sshd_config reports a false negative. What matters is that a password login
+# is actually refused.
+#
+# Capture the output first rather than piping into `grep -q`: under `pipefail`
+# a pipeline reports the *first* non-zero status, and this ssh always exits 255
+# on the refusal we are trying to observe, so the grep result would be masked.
+PWSSH="$(ssh -o PreferredAuthentications=password -o PubkeyAuthentication=no \
+             -o StrictHostKeyChecking=no -o ConnectTimeout=10 \
+             "root@${VPS}" true </dev/null 2>&1 || true)"
+case "$PWSSH" in
+    *"Permission denied"*) pass "password login refused" ;;
+    *) fail "password login refused — got '${PWSSH}'" ;;
+esac
+check "sshd effective passwordauthentication" \
+  "$($SSH "sshd -T | grep '^passwordauthentication' | awk '{print \$2}'")" "no"
+
+echo
+echo "== Services =="
+check "six units active" \
+  "$($SSH 'systemctl is-active postgresql formava-api formava-web clio clio-cron nginx | sort -u | tr -d "\n"')" \
+  "active"
+check "api MemoryMax" \
+  "$($SSH 'systemctl show formava-api -p MemoryMax --value')" "805306368"
+check "web MemoryMax" \
+  "$($SSH 'systemctl show formava-web -p MemoryMax --value')" "536870912"
+check "gradio absent from host" \
+  "$($SSH 'test -e /opt/formava/app/pages; echo $?')" "1"
+
+echo
+echo "== fail2ban =="
+# A jail reports "active" even when it is monitoring nothing: defaults-debian
+# sets backend=systemd, which silently overrides logpath. Assert the file, not
+# the status. sshd is exempt — it reads the journal by design and works.
+check "sshd jail active" \
+  "$($SSH 'fail2ban-client status sshd >/dev/null 2>&1; echo $?')" "0"
+for jail in nginx-badbots nginx-http-auth clio-capture-auth; do
+    LOGPATH="$($SSH "fail2ban-client get ${jail} logpath 2>/dev/null" | grep -oE '/var/log/[^ ]+')"
+    [ -n "$LOGPATH" ] \
+      && pass "jail ${jail} reads ${LOGPATH}" \
+      || fail "jail ${jail} monitors no file (backend=systemd override?)"
+done
+
+echo
+echo "== Backups =="
+check "backup timer" "$($SSH 'systemctl is-active formava-backup.timer')" "active"
+$SSH 'ls /var/backups/formava/*.sql.gz >/dev/null 2>&1' \
+  && pass "backup artifact present" || fail "backup artifact present"
+
+echo
+echo "== TLS =="
+$SSH 'certbot renew --dry-run' >/dev/null 2>&1 \
+  && pass "cert renewal dry-run" || fail "cert renewal dry-run"
+
+echo
+echo "== Memory =="
+$SSH 'free -h | head -2'
+
+echo
+[ "$FAIL" -eq 0 ] && echo "ALL CHECKS PASSED" || echo "SOME CHECKS FAILED"
+exit "$FAIL"

--- a/scripts/vps/verify.sh
+++ b/scripts/vps/verify.sh
@@ -8,6 +8,11 @@
 # this script's environment rather than passed in, so no secret reaches shell
 # history or the process table of another user.
 #
+# Runtime is roughly a minute from cold, but climbs toward five if it is run
+# several times in quick succession: the /capture rate-limit bucket refills at
+# one slot every 6s and the backoff below waits for it. A long pause during the
+# Clio section is the script being patient, not hung.
+#
 # `set -e` is deliberately omitted: a failing check must not abort the run.
 # Every assertion should report, and the exit code is the roll-up.
 set -uo pipefail

--- a/tests/integration/test_health_checks.py
+++ b/tests/integration/test_health_checks.py
@@ -1,0 +1,29 @@
+import os
+
+import psycopg
+import pytest
+
+from app.health.checks import PostgresHealth, check_postgres
+
+DSN = os.environ.get(
+    "FORMAVA_TEST_DSN",
+    "postgresql://formava:formava_dev@localhost:5432/formava",
+)
+
+
+def test_check_postgres_reports_ok_and_pgvector_version():
+    result = check_postgres(DSN)
+
+    assert isinstance(result, PostgresHealth)
+    assert result.db == "ok"
+    # pgvector reports a semver-ish string such as "0.6.0" or "0.8.0"
+    assert result.pgvector
+    assert result.pgvector[0].isdigit()
+
+
+def test_check_postgres_raises_when_database_unreachable():
+    bad_dsn = "postgresql://formava:formava_dev@localhost:59999/formava"
+
+    # Must raise, never return a degraded value. No silent fallback.
+    with pytest.raises(psycopg.Error):
+        check_postgres(bad_dsn)

--- a/tests/unit/test_health_api.py
+++ b/tests/unit/test_health_api.py
@@ -44,3 +44,17 @@ def test_health_returns_503_when_database_unreachable(client_with_broken_db):
 def test_create_app_requires_a_dsn():
     with pytest.raises(ValueError, match="DSN"):
         create_app(dsn="")
+
+
+def test_create_app_reads_dsn_from_environment(monkeypatch):
+    monkeypatch.setenv("FORMAVA_DATABASE_URL", "postgresql://from-env")
+    # Must not raise: this is the production invocation, uvicorn --factory
+    # calls create_app() with no arguments.
+    app = create_app()
+    assert app is not None
+
+
+def test_create_app_raises_when_environment_dsn_is_absent(monkeypatch):
+    monkeypatch.delenv("FORMAVA_DATABASE_URL", raising=False)
+    with pytest.raises(ValueError, match="DSN"):
+        create_app()

--- a/tests/unit/test_health_api.py
+++ b/tests/unit/test_health_api.py
@@ -1,0 +1,46 @@
+import psycopg
+import pytest
+from fastapi.testclient import TestClient
+
+from app.health.api import create_app
+from app.health.checks import PostgresHealth
+
+
+@pytest.fixture
+def client_with_healthy_db(monkeypatch):
+    def fake_check(dsn: str) -> PostgresHealth:
+        return PostgresHealth(db="ok", pgvector="0.6.0")
+
+    monkeypatch.setattr("app.health.api.check_postgres", fake_check)
+    return TestClient(create_app(dsn="postgresql://unused"))
+
+
+@pytest.fixture
+def client_with_broken_db(monkeypatch):
+    def fake_check(dsn: str) -> PostgresHealth:
+        raise psycopg.OperationalError("connection refused")
+
+    monkeypatch.setattr("app.health.api.check_postgres", fake_check)
+    return TestClient(
+        create_app(dsn="postgresql://unused"), raise_server_exceptions=False
+    )
+
+
+def test_health_returns_exact_spec_shape(client_with_healthy_db):
+    response = client_with_healthy_db.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"db": "ok", "pgvector": "0.6.0"}
+
+
+def test_health_returns_503_when_database_unreachable(client_with_broken_db):
+    response = client_with_broken_db.get("/health")
+
+    # Must fail loudly. A degraded 200 would defeat the purpose.
+    assert response.status_code == 503
+    assert "connection refused" in response.json()["detail"]
+
+
+def test_create_app_requires_a_dsn():
+    with pytest.raises(ValueError, match="DSN"):
+        create_app(dsn="")

--- a/tests/unit/test_hevy_api.py
+++ b/tests/unit/test_hevy_api.py
@@ -69,20 +69,30 @@ def test_get_workouts_pagination(mock_request, hevy_api_instance):
 
 @patch("app.services.hevy_api.requests.request")
 def test_get_workouts_handles_http_error(mock_request, hevy_api_instance):
-    # Arrange
+    # Arrange: a realistic 401 response. Real raise_for_status() raises,
+    # which is what drives hevy_api's retry-then-propagate path.
     mock_response = MagicMock()
     mock_response.status_code = 401
-    mock_response.text = "Unauthorized"
+    mock_response.text = "InvalidApiKey"
     mock_response.headers = {}
     mock_response.request.url = "http://fake.url"
     mock_response.request.headers = {}
-    # Don't raise from raise_for_status(); let get_workouts() check status_code
+    http_error = requests.exceptions.HTTPError("401 Client Error: Unauthorized")
+    http_error.response = mock_response
+    mock_response.raise_for_status.side_effect = http_error
     mock_request.return_value = mock_response
+
+    # Keep the test fast without changing the code path: retries still run,
+    # they just don't sleep. This exercises the real retry logic at
+    # _make_request_with_retry:99-109 without the 7s of backoff delays.
+    hevy_api_instance.retry_delay = 0
 
     # Act & Assert
     with pytest.raises(requests.exceptions.HTTPError) as excinfo:
         hevy_api_instance.get_workouts()
-    # get_workouts() raises its own HTTPError with this message for 401
-    assert "401 Unauthorized" in str(excinfo.value)
+
+    assert "401 Client Error" in str(excinfo.value)
+    # The wrapper retries before giving up, so more than one attempt happens.
+    assert mock_request.call_count == hevy_api_instance.max_retries + 1
     # Guard: a wrong patch target would silently hit the real API instead.
     assert mock_request.called

--- a/tests/unit/test_hevy_api.py
+++ b/tests/unit/test_hevy_api.py
@@ -20,15 +20,15 @@ def mock_response(workouts, page_count=1):
     return {"workouts": workouts, "page_count": page_count}
 
 
-@patch("app.services.hevy_api.requests.get")
-def test_get_workouts_filters_by_date(mock_get, hevy_api_instance):
+@patch("app.services.hevy_api.requests.request")
+def test_get_workouts_filters_by_date(mock_request, hevy_api_instance):
     # Arrange
     start_date = datetime(2025, 5, 23, tzinfo=timezone.utc)
     end_date = datetime(2025, 6, 22, tzinfo=timezone.utc)
     # One workout inside, one outside the range
     inside = make_workout("2025-06-01T10:00:00+00:00")
     outside = make_workout("2025-05-01T10:00:00+00:00")
-    mock_get.return_value = MagicMock(
+    mock_request.return_value = MagicMock(
         status_code=200, json=lambda: mock_response([inside, outside], page_count=1)
     )
 
@@ -38,10 +38,12 @@ def test_get_workouts_filters_by_date(mock_get, hevy_api_instance):
     # Assert
     assert len(results) == 1
     assert results[0]["start_time"] == inside["start_time"]
+    # Guard: a wrong patch target would silently hit the real API instead.
+    assert mock_request.called
 
 
-@patch("app.services.hevy_api.requests.get")
-def test_get_workouts_pagination(mock_get, hevy_api_instance):
+@patch("app.services.hevy_api.requests.request")
+def test_get_workouts_pagination(mock_request, hevy_api_instance):
     # Arrange
     start_date = datetime(2025, 5, 23, tzinfo=timezone.utc)
     end_date = datetime(2025, 6, 22, tzinfo=timezone.utc)
@@ -49,7 +51,7 @@ def test_get_workouts_pagination(mock_get, hevy_api_instance):
     page1 = make_workout("2025-06-01T10:00:00+00:00")
     page2 = make_workout("2025-06-10T10:00:00+00:00")
     # Set up side effects for pagination
-    mock_get.side_effect = [
+    mock_request.side_effect = [
         MagicMock(status_code=200, json=lambda: mock_response([page1], page_count=2)),
         MagicMock(status_code=200, json=lambda: mock_response([page2], page_count=2)),
     ]
@@ -61,10 +63,12 @@ def test_get_workouts_pagination(mock_get, hevy_api_instance):
     assert len(results) == 2
     assert results[0]["start_time"] == page1["start_time"]
     assert results[1]["start_time"] == page2["start_time"]
+    # Guard: a wrong patch target would silently hit the real API instead.
+    assert mock_request.called
 
 
-@patch("app.services.hevy_api.requests.get")
-def test_get_workouts_handles_http_error(mock_get, hevy_api_instance):
+@patch("app.services.hevy_api.requests.request")
+def test_get_workouts_handles_http_error(mock_request, hevy_api_instance):
     # Arrange
     mock_response = MagicMock()
     mock_response.status_code = 401
@@ -72,16 +76,13 @@ def test_get_workouts_handles_http_error(mock_get, hevy_api_instance):
     mock_response.headers = {}
     mock_response.request.url = "http://fake.url"
     mock_response.request.headers = {}
-
-    # Create the HTTPError and attach the mock_response
-    http_error = requests.exceptions.HTTPError("401 Unauthorized: Invalid API key")
-    http_error.response = mock_response
-
-    # Set the side_effect to the *instance*, not the class or a lambda
-    mock_response.raise_for_status.side_effect = http_error
-    mock_get.return_value = mock_response
+    # Don't raise from raise_for_status(); let get_workouts() check status_code
+    mock_request.return_value = mock_response
 
     # Act & Assert
     with pytest.raises(requests.exceptions.HTTPError) as excinfo:
         hevy_api_instance.get_workouts()
+    # get_workouts() raises its own HTTPError with this message for 401
     assert "401 Unauthorized" in str(excinfo.value)
+    # Guard: a wrong patch target would silently hit the real API instead.
+    assert mock_request.called


### PR DESCRIPTION
Migrates Formava off Render onto a self-hosted VPS, alongside the existing Clio deployment. Render stays live and untouched as the fallback until Spec 4 retires it.

## What's live

| | |
|---|---|
| `https://formava.io/api/health` | `{"db":"ok","pgvector":"0.6.0"}` |
| `https://www.formava.io/` | 301 → apex |
| `https://clio.lantzbuilds.com/health` | 200 |
| port 3000 | closed at ufw, unreachable off-host |
| ssh | key-only, passwords refused |
| fail2ban | 4 jails, all reading real log files |
| backups | nightly timer, restore + size guard proven |

Six units active: `postgresql`, `formava-api`, `formava-web`, `clio`, `clio-cron`, `nginx`. Host memory ~900 MB of 3.8 GB.

## Verification

`scripts/vps/verify.sh` asserts every Spec 1 exit criterion and is safe to re-run. 40/40 checks pass, twice back to back.

Two problems it surfaced about itself, both fixed:

- It provokes 401s to prove auth works, which is exactly what the `clio-capture-auth` jail bans on (maxretry 5, bantime 24h). One run locked the operator out for a day. The Clio section is now bracketed by a jail-scoped `ignoreip`, released right after the last auth probe and again via an `EXIT` trap.
- nginx rate-limits `/capture` to 10r/m burst 5, and the script spends the whole burst, so a second run inside the minute drew 503s. Capture-zone requests now back off and retry.

Auth probes are deliberately side-effect-free: `/capture` posts an empty object so it clears auth then fails validation with 400 rather than filing junk captures, and the session token is proven with a `GET` on a non-existent id.

## CI

Both Render echo-stubs are replaced by a single `deploy-vps` job on `main`. The import smoke-test moved from `app.main` (pulls in Gradio, hard-requires CouchDB, which neither CI nor the VPS has) to `app.health.api:create_app`, the entrypoint the `formava-api` unit actually runs.

**Before merging, add two repo secrets:** `VPS_SSH_KEY` (a dedicated deploy key, not a personal one) and `VPS_HOST`.

## Known, not blocking

- Clio model id `claude-sonnet-4-20250514` 404s; capture analysis silently falls back. Clio-side fix.
- Clio still binds `0.0.0.0` on 3000; ufw is what closes it. One-line `listen()` change, open on the Clio side.
- CI lint and the import test are scoped to `app/health/` on purpose. The Gradio layer carries 107 pre-existing ruff violations and is deleted in Spec 4.

Authored by Lantz with Claude Code 🤖

https://claude.ai/code/session_01WFbvnX5dgyBoZWQH5FNjus